### PR TITLE
fix unicode problem (in Python 2), and "check_call" rather than "call"

### DIFF
--- a/align_videos_by_sound_track.py
+++ b/align_videos_by_sound_track.py
@@ -167,7 +167,7 @@ class SyncDetector(object):
                     "-f", "wav",
                     "%s" % output
                     ]))
-            #logging.debug(cmd)
+            #_logger.debug(cmd)
             subprocess.check_call(map(_encode, cmd), stderr=open(os.devnull, 'w'))
         return output
 


### PR DESCRIPTION
In the case of my Windows 7 Japanese edition environment, the test file to reproduce the Unicode problem can be created just by performing the copy operation in the Explorer, but because it seems to be annoying to manage, I did not add the test file.