### PR TITLE
trim_post, pad_post

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -155,30 +155,25 @@ class SyncDetector(object):
         """
         Find time delays between video files
         """
+        def _each(idx):
+            wavfile = self._extract_audio(files[idx], idx)
+            raw_audio, rate = communicate.read_audio(wavfile)
+            bins_dict = _make_horiz_bins(
+                raw_audio,
+                fft_bin_size, overlap, box_height)  # bins, overlap, box height
+            del raw_audio
+            boxes = _make_vert_bins(bins_dict, box_width)  # box width
+            ft_dict = _find_bin_max(boxes, samples_per_box)  # samples per box
+            del boxes
+            return rate, ft_dict
+        #
         tmp_result = [0.0]
 
         # Process first file
-        wavfile1 = self._extract_audio(files[0], 0)
-        raw_audio1, rate = communicate.read_audio(wavfile1)
-        bins_dict1 = _make_horiz_bins(
-            raw_audio1,
-            fft_bin_size, overlap, box_height)  # bins, overlap, box height
-        del raw_audio1
-        boxes1 = _make_vert_bins(bins_dict1, box_width)  # box width
-        ft_dict1 = _find_bin_max(boxes1, samples_per_box)  # samples per box
-        del boxes1
-
+        rate, ft_dict1 = _each(0)
         for i in range(len(files) - 1):
             # Process second file
-            wavfile2 = self._extract_audio(files[i + 1], i + 1)
-            raw_audio2, rate = communicate.read_audio(wavfile2)
-            bins_dict2 = _make_horiz_bins(
-                raw_audio2,
-                fft_bin_size, overlap, box_height)
-            del raw_audio2
-            boxes2 = _make_vert_bins(bins_dict2, box_width)
-            ft_dict2 = _find_bin_max(boxes2, samples_per_box)
-            del boxes2
+            rate, ft_dict2 = _each(i + 1)
 
             # Determie time delay
             pairs = _find_freq_pairs(ft_dict1, ft_dict2)

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -239,6 +239,7 @@ class SyncDetector(object):
                 {
                     "trim": trim_pre[i],
                     "pad": pad_pre[i],
+                    "orig_duration": orig_dur[i],
                     "trim_post": trim_post[i],
                     "pad_post": pad_post[i],
                     }

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -118,7 +118,7 @@ def get_media_info(filename):
         map(int,
             re.search(
                 rgx,
-                err.decode(sys.stdout.encoding)).group(1, 2, 3, 4)))
+                err.decode("utf-8")).group(1, 2, 3, 4)))
     return {
         "duration": tp[0] * 60 * 60 + tp[1] * 60 + tp[2] + tp[3] / 100.,
         }

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+#
+"""
+This module contains helpers for cooperation processing with
+external programs (such as ffmpeg) on ​​which this library depends.
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import subprocess
+import sys
+import re
+import logging
+
+import scipy.io.wavfile
+
+__all__ = [
+    "check_call", "check_stderroutput",
+    "read_audio",
+    "get_media_info",
+    ]
+
+_logger = logging.getLogger(__name__)
+
+
+if hasattr("", "decode"):  # python 2
+    def _encode(s):
+        return s.encode(sys.stdout.encoding)
+else:
+    def _encode(s):
+        return s
+
+
+# ##################################
+#
+# low-level APIs
+#
+
+def _filter_args(*cmd):
+    """
+    do filtering None, and do encoding items to bytes
+    (in Python 2).
+    """
+    return map(_encode, filter(None, *cmd))
+
+    
+def check_call(*popenargs, **kwargs):
+    """
+    Basically do simply forward args to subprocess#check_call, but this
+    does two things:
+
+    * It does encoding these to bytes in Python 2.
+    * It does omitting `None` in *cmd.
+    
+    """
+    cmd = kwargs.get("args")
+    if cmd is None:
+        cmd = popenargs[0]
+    subprocess.check_call(
+        _filter_args(cmd), **kwargs)
+
+
+def check_stderroutput(*popenargs, **kwargs):
+    """
+    Unfortunately, ffmpeg and ffprobe throw out the information
+    we want into the standard error output, and subprocess.check_output
+    discards the standard error output. This function is obtained by
+    rewriting subprocess.check_output for standard error output.
+
+    And this does two things:
+
+    * It does encoding these to bytes in Python 2.
+    * It does omitting `None` in *cmd.
+    """
+    if 'stderr' in kwargs:
+        raise ValueError(
+            'stderr argument not allowed, it will be overridden.')
+    cmd = kwargs.get("args")
+    if cmd is None:
+        cmd = popenargs[0]
+    #
+    process = subprocess.Popen(
+        _filter_args(cmd),
+        stderr=subprocess.PIPE,
+        **kwargs)
+    stdout_output, stderr_output = process.communicate()
+    retcode = process.poll()
+    if retcode:
+        raise subprocess.CalledProcessError(
+            retcode, cmd, output=stderr_output)
+    return stderr_output
+
+
+# ##################################
+#
+# higher-level APIs
+#
+def read_audio(audio_file):
+    """
+    Read file
+
+    INPUT: Audio file
+    OUTPUT: Sets sample rate of wav file, Returns data read from wav file (numpy array of integers)
+    """
+    rate, data = scipy.io.wavfile.read(audio_file)  # Return the sample rate (in samples/sec) and data from a WAV file
+    return data, rate
+
+
+def get_media_info(filename):
+    """
+    return the information extracted by ffprobe.
+
+    for now, this function extracts only its duration.
+    """
+    err = check_stderroutput(["ffprobe", filename])
+    rgx = r"Duration: (\d{2}):(\d{2}):(\d{2}).(\d{2})"
+    tp = list(
+        map(int,
+            re.search(
+                rgx,
+                err.decode(sys.stdout.encoding)).group(1, 2, 3, 4)))
+    return {
+        "duration": tp[0] * 60 * 60 + tp[1] * 60 + tp[2] + tp[3] / 100.,
+        }


### PR DESCRIPTION
With the request to align the start of media with audio, I think that it is often that you want to align the terminations. In fact, the script I am creating is also requiring padding at the end. Fortunately, dependency on `ffmpeg` is equivalent to dependency on `ffprobe`, you can get duration with `ffprobe`.

There are two pending issues.

* Whether the names "trim_post" and "pad_post" are indeed suitable?
* Maybe some people are not pleased if we call `ffprobe` unconditionally?

For the latter personally, I think that the cost of the `ffprobe` call is within the error range when handling realistic length movies, so there is no problem.