### PR TITLE
Improving simple_stack_videos_by_sound_track

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -251,7 +251,7 @@ def main(args=sys.argv):
     parser = argparse.ArgumentParser(prog=args[0], usage=_doc_template)
     parser.add_argument(
         '--max_misalignment',
-        type=int, default=2*60,
+        type=float, default=2*60,
         help='When handling media files with long playback time, \
 it may take a huge amount of time and huge memory. \
 In such a case, by changing this value to a small value, \

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -254,8 +254,11 @@ def _build(args):
     filters = []
     r0, vm0, am0 = b.build_each_streams()
     filters.extend(r0)
-    r1, vm1 = b.build_stack_videos(vm0)
-    filters.extend(r1)
+    if args.video_mode == "stack":
+        r1, vm1 = b.build_stack_videos(vm0)
+        filters.extend(r1)
+    else:
+        vm1 = vm0
     if args.audio_mode == "amerge":
         r2, am = b.build_amerge_audio(am0)
         filters.extend(r2)
@@ -284,6 +287,10 @@ Switching whether to produce bash shellscript or to call ffmpeg directly.""")
         '--audio_mode', choices=['amerge', 'multi_streams'], default='amerge',
         help="""\
 Switching whether to merge audios or to keep each as multi streams.""")
+    parser.add_argument(
+        '--video_mode', choices=['stack', 'multi_streams'], default='stack',
+        help="""\
+Switching whether to stack videos or to keep each as multi streams.""")
     parser.add_argument(
         '--max_misalignment', type=float, default=2*60,
         help="""\

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -257,7 +257,7 @@ def main(args=sys.argv):
         help="""\
 Switching whether to produce bash shellscript or to call ffmpeg directly.""")
     parser.add_argument(
-        '--max_misalignment', type=int, default=2*60,
+        '--max_misalignment', type=float, default=2*60,
         help="""\
 See the help of alignment_info_by_sound_track.""")
     parser.add_argument(


### PR DESCRIPTION
* Re: [your comment](https://github.com/jeorgen/align-videos-by-sound/pull/14#issuecomment-401306800). I do not know my enhancement is what you say, but I prepared a mode to map to multi-stream. At least the VLC media player can handle this , and the user can switch streams.
* I noticed that ffmpeg ends with an error when one movie that does not require padding is included. Although I did not know the correct solution, I was able to avoid this problem by adding padding, so I added padding as a workaround.
* When the number of files does not match the shape, we will use the file passed without error as it is repeatedly used.
* It is not related to this theme but "max_misalignment" is correct for float. I fixed it.
