### PR TITLE
Workaround for "rmtree" to rarely fail, etc.

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -120,7 +120,15 @@ class SyncDetector(object):
         return self
 
     def __exit__(self, type, value, tb):
-        shutil.rmtree(self._working_dir)
+        retry = 3
+        while retry > 0:
+            try:
+                shutil.rmtree(self._working_dir)
+                break
+            except:
+                import time
+                retry -= 1
+                time.sleep(1)
 
     def _extract_audio(self, sample_rate, video_file, idx):
         """
@@ -140,7 +148,7 @@ class SyncDetector(object):
             self._orig_infos[fn] = communicate.get_media_info(fn)
         return self._orig_infos[fn]
 
-    def _align(self, sample_rate, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, samples_per_box=7):
+    def _align(self, sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box):
         """
         Find time delays between video files
         """
@@ -237,7 +245,7 @@ def main(args=sys.argv):
     parser = argparse.ArgumentParser(prog=args[0], usage=_doc_template)
     parser.add_argument(
         '--max_misalignment',
-        type=float, default=2*60,
+        type=float, default=10*60,
         help='When handling media files with long playback time, \
 it may take a huge amount of time and huge memory. \
 In such a case, by changing this value to a small value, \

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -105,7 +105,16 @@ def read_audio(audio_file):
     INPUT: Audio file
     OUTPUT: Sets sample rate of wav file, Returns data read from wav file (numpy array of integers)
     """
-    rate, data = scipy.io.wavfile.read(audio_file)  # Return the sample rate (in samples/sec) and data from a WAV file
+    # Return the sample rate (in samples/sec) and data from a WAV file
+
+    # By using mmap you can reduce memory usage. I do not know whether this is good from
+    # the viewpoint of processing speed. However, when dealing with a realistic movie that
+    # this package deals with, the most problematic is the memory used. For example, If
+    # a poor PC with only 4 GB of physical memory handles a movie of about "VERY SHORT" 20
+    # minutes, it will cause you to fall into a state where you can not do any work.
+    rate, data = scipy.io.wavfile.read(
+        audio_file,
+        mmap=True)
     return data, rate
 
 

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -348,7 +348,7 @@ If the key is blank, it means all input streams. Only single input / single outp
 filters can be used.""")
     #####
     parser.add_argument(
-        '--max_misalignment', type=float, default=2*60,
+        '--max_misalignment', type=float, default=10*60,
         help="""\
 See the help of alignment_info_by_sound_track. (default: %(default)d)""")
     parser.add_argument(


### PR DESCRIPTION
* Occasionally, rmtree may run before ffmpeg finishes termination processing, especially on windows where exclusion control is severe, cleanup may not succeed. Therefore, I decided to retry several times.
* I increased the default of max_misalignment. Because the memory usage per unit time was drastically reduced by previous remodeling. Especially for movies that simple_stack_videos_by_sound_track handles, it often happens that there is a gap in the shooting start time of about 5 minutes, so I often forget to specify max_misalignment.
* I removed the default argument specification of the "_ align" method because it is redundant.
* mmap=True for memory usage.