### PR TITLE
ffmpeg_filter_graph.py, etc.

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -36,6 +36,8 @@ import logging
 import numpy as np
 
 from . import communicate
+from .utils import check_and_decode_filenames
+
 
 __all__ = [
     'SyncDetector',
@@ -43,14 +45,6 @@ __all__ = [
     ]
 
 _logger = logging.getLogger(__name__)
-
-
-if hasattr("", "decode"):  # python 2
-    def _decode(s):
-        return s.decode(sys.stdout.encoding)
-else:
-    def _decode(s):
-        return s
 
 
 def _mk_freq_trans_summary(data, fft_bin_size, overlap, box_height, box_width, maxes_per_box):
@@ -298,14 +292,13 @@ It is possible to pass any media that ffmpeg can handle.',)
 
     logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
+    file_specs = []
     if args.file_names and len(args.file_names) >= 2:
-        file_specs = list(map(_decode, map(os.path.abspath, args.file_names)))
+        file_specs = check_and_decode_filenames(args.file_names)
         # _logger.debug(file_specs)
     else:  # No pipe and no input file, print help text and exit
         _bailout(parser)
-    non_existing_files = [path for path in file_specs if not os.path.isfile(path)]
-    if non_existing_files:
-        print("** The following are not existing files: %s **" % (','.join(non_existing_files),))
+    if not file_specs:
         _bailout(parser)
 
     with SyncDetector(

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -190,16 +190,16 @@ class SyncDetector(object):
         # build result
         pad_pre = result - result.min()
         trim_pre = -(pad_pre - pad_pre.max())
-        orig_dur = np.array([
-                self._get_media_info(fn)["duration"]
-                for fn in files])
+        infos = [self._get_media_info(fn) for fn in files]
+        orig_dur = np.array([inf["duration"] for inf in infos])
+        strms_info = [inf["streams"] for inf in infos]
         pad_post = list(
             (pad_pre + orig_dur).max() - (pad_pre + orig_dur))
         trim_post = list(
             (orig_dur - trim_pre) - (orig_dur - trim_pre).min())
 
         #
-        return pad_pre, trim_pre, orig_dur, pad_post, trim_post
+        return pad_pre, trim_pre, orig_dur, strms_info, pad_post, trim_post
 
     def align(self, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, samples_per_box=7,
               max_misalignment=0, known_delay_ge_map={}):
@@ -207,7 +207,7 @@ class SyncDetector(object):
         Find time delays between video files
         """
         # First, try finding delays roughly by passing low sample rate.
-        pad_pre, trim_pre, orig_dur, pad_post, trim_post = self._align(
+        pad_pre, trim_pre, orig_dur, strms_info, pad_post, trim_post = self._align(
             44100 // 12, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
             max_misalignment, known_delay_ge_map)
 
@@ -219,7 +219,7 @@ class SyncDetector(object):
         max_misalignment = 15
 
         # Finally, try finding delays precicely
-        pad_pre, trim_pre, orig_dur, pad_post, trim_post = self._align(
+        pad_pre, trim_pre, orig_dur, strms_info, pad_post, trim_post = self._align(
             self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
             max_misalignment, known_delay_ge_map)
 
@@ -233,6 +233,7 @@ class SyncDetector(object):
                     "orig_duration": orig_dur[i],
                     "trim_post": trim_post[i],
                     "pad_post": pad_post[i],
+                    "orig_streams": strms_info[i],
                     }
                 ]
             for i in range(len(files))]

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -130,7 +130,7 @@ class SyncDetector(object):
                 retry -= 1
                 time.sleep(1)
 
-    def _extract_audio(self, sample_rate, video_file, idx):
+    def _extract_audio(self, sample_rate, video_file, starttime_offset, duration):
         """
         Extract audio from video file, save as wav auido file
 
@@ -139,8 +139,8 @@ class SyncDetector(object):
         """
         return communicate.media_to_mono_wave(
             video_file, self._working_dir,
-            starttime_offset=self._known_delay_ge_map.get(idx, 0),
-            duration=self._max_misalignment * 2,
+            starttime_offset=starttime_offset,
+            duration=duration,
             sample_rate=sample_rate)
 
     def _get_media_info(self, fn):
@@ -153,7 +153,10 @@ class SyncDetector(object):
         Find time delays between video files
         """
         def _each(idx):
-            wavfile = self._extract_audio(sample_rate, files[idx], idx)
+            wavfile = self._extract_audio(
+                sample_rate, files[idx],
+                starttime_offset=self._known_delay_ge_map.get(idx, 0),
+                duration=self._max_misalignment * 2)
             raw_audio, rate = communicate.read_audio(wavfile)
             ft_dict = _mk_freq_trans_summary(
                 raw_audio,

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -190,7 +190,9 @@ def _parse_ffprobe_output(inputstr):
             continue
         ifidx, strmidx, strmtype, rest = m.group(1, 2, 3, 4)
         if strmtype == "Video":
-            enc, _, resol, _, fps, _, _, _ = _split_csv(rest)
+            spl = _split_csv(rest)
+            resol = list(filter(lambda item: re.search(r"[1-9]\d*x[1-9]\d*", item), spl))[0]
+            fps = list(filter(lambda item: re.search(r"[\d.]+ fps", item), spl))[0]
             strms_tmp[int(strmidx)] = {
                 "type": strmtype,
                 "resolution": [
@@ -200,7 +202,8 @@ def _parse_ffprobe_output(inputstr):
                 "fps": float(fps.split(" ")[0]),
                 }
         elif strmtype == "Audio":
-            enc, ar, chlay, _, _ = _split_csv(rest)
+            spl = _split_csv(rest)
+            ar = list(filter(lambda item: re.search(r"\d+ Hz", item), spl))[0]
             strms_tmp[int(strmidx)] = {
                 "type": strmtype,
                 "sample_rate": int(re.match(r"(\d+) Hz", ar).group(1)),

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -118,11 +118,102 @@ def read_audio(audio_file):
     return data, rate
 
 
+def _parse_ffprobe_output(inputstr):
+    r"""
+    >>> import json
+    >>> s = '''Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'input.mp4':
+    ...  Metadata:
+    ...    major_brand     : isom
+    ...    minor_version   : 512
+    ...    compatible_brands: isomiso2avc1mp41
+    ...    encoder         : Lavf56.40.101
+    ...  Duration: 00:24:59.55, start: 0.000000, bitrate: 4457 kb/s
+    ...    Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(tv, bt709), 1920x1080 [SAR 1:1 DAR 16:9], 4324 kb/s, 29.97 fps, 29.97 tbr, 90k tbn, 59.94 tbc (default)
+    ...    Metadata:
+    ...      handler_name    : VideoHandler
+    ...    Stream #0:1(und): Audio: aac (LC) (mp4a / 0x6134706D), 44100 Hz, stereo, fltp, 125 kb/s (default)
+    ...    Metadata:
+    ...      handler_name    : SoundHandler'''
+    >>> result = _parse_ffprobe_output(s)
+    >>> print(json.dumps(result, indent=2, sort_keys=True).replace(', \n', ',\n'))
+    {
+      "duration": 1499.55,
+      "streams": [
+        {
+          "fps": 29.97,
+          "resolution": [
+            [
+              1920,
+              1080
+            ],
+            "[SAR 1:1 DAR 16:9]"
+          ],
+          "type": "Video"
+        },
+        {
+          "sample_rate": 44100,
+          "type": "Audio"
+        }
+      ]
+    }
+    """
+    def _split_csv(s):
+        ss = s.split(", ")
+        result = []
+        i = 0
+        while i < len(ss):
+            result.append(ss[i])
+            while i < len(ss) - 1 and \
+                    result[-1].count("(") != result[-1].count(")"):
+                i += 1
+                result[-1] = ", ".join((result[-1], ss[i]))
+            i += 1
+        return result
+        
+    result = {"streams": []}
+    lines = inputstr.split("\n")
+    rgx = r"Duration: (\d{2}):(\d{2}):(\d{2}).(\d{2})"
+    while lines:
+        line = lines.pop(0)
+        m = re.search(rgx, line)
+        if m:
+            tp = list(map(int, m.group(1, 2, 3, 4)))
+            result["duration"] = \
+                tp[0] * 60 * 60 + tp[1] * 60 + tp[2] + tp[3] / 100.
+            break
+    #
+    rgx = r"Stream #(\d+):(\d+)\(\w+\): ([^:]+): (.*)$"
+    strms_tmp = {}
+    for line in lines:
+        m = re.search(rgx, line)
+        if not m:
+            continue
+        ifidx, strmidx, strmtype, rest = m.group(1, 2, 3, 4)
+        if strmtype == "Video":
+            enc, _, resol, _, fps, _, _, _ = _split_csv(rest)
+            strms_tmp[int(strmidx)] = {
+                "type": strmtype,
+                "resolution": [
+                    list(map(int, s.split("x"))) if i == 0 else s
+                    for i, s in enumerate(resol.partition(" ")[0::2])
+                    ],
+                "fps": float(fps.split(" ")[0]),
+                }
+        elif strmtype == "Audio":
+            enc, ar, chlay, _, _ = _split_csv(rest)
+            strms_tmp[int(strmidx)] = {
+                "type": strmtype,
+                "sample_rate": int(re.match(r"(\d+) Hz", ar).group(1)),
+                }
+        #elif strmtype == "Subtitle"?
+    for i in sorted(strms_tmp.keys()):
+        result["streams"].append(strms_tmp[i])
+    return result
+
+
 def get_media_info(filename):
     """
     return the information extracted by ffprobe.
-
-    for now, this function extracts only its duration.
     """
     # If processing is progressed when there is no input file, exception
     # reporting is considerably troublesome. Therefore, we decide to check
@@ -130,15 +221,7 @@ def get_media_info(filename):
     os.path.getatime(filename)
 
     err = check_stderroutput(["ffprobe", "-hide_banner", filename])
-    rgx = r"Duration: (\d{2}):(\d{2}):(\d{2}).(\d{2})"
-    tp = list(
-        map(int,
-            re.search(
-                rgx,
-                err.decode("utf-8")).group(1, 2, 3, 4)))
-    return {
-        "duration": tp[0] * 60 * 60 + tp[1] * 60 + tp[2] + tp[3] / 100.,
-        }
+    return _parse_ffprobe_output(err.decode("utf-8"))
 
 
 def duration_to_hhmmss(duration):
@@ -193,3 +276,8 @@ def media_to_mono_wave(
         #_logger.debug(cmd)
         check_call(cmd, stderr=open(os.devnull, 'w'))
     return output
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -129,7 +129,7 @@ def get_media_info(filename):
     # existence in getatime to understand easily.
     os.path.getatime(filename)
 
-    err = check_stderroutput(["ffprobe", filename])
+    err = check_stderroutput(["ffprobe", "-hide_banner", filename])
     rgx = r"Duration: (\d{2}):(\d{2}):(\d{2}).(\d{2})"
     tp = list(
         map(int,
@@ -180,7 +180,7 @@ def media_to_mono_wave(
     output = os.path.join(out_dir, audio_output)
     if not os.path.exists(output):
         cmd = [
-                "ffmpeg", "-y",
+                "ffmpeg", "-hide_banner", "-y",
                 _ffmpeg_ss_args[0], _ffmpeg_ss_args[1],
                 ffmpeg_t_args[0], ffmpeg_t_args[1],
                 "-i", "%s" % video_file,

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -10,6 +10,7 @@ from itertools import chain
 import logging
 
 __all__ = [
+    "mk_single_filter_body",
     "Filter",
     "ConcatWithGapFilterGraphBuilder",
     ]
@@ -27,13 +28,13 @@ _filter_defaults = {
     }
 
 
-def _mk_single_filter_body(name, *args, **kwargs):
+def mk_single_filter_body(name, *args, **kwargs):
     r"""
-    >>> print(_mk_single_filter_body("color", s="960x540", d="123.45"))
+    >>> print(mk_single_filter_body("color", s="960x540", d="123.45"))
     color=c=black:d=123.45:s=960x540
-    >>> print(_mk_single_filter_body("scale", "600", "400"))
+    >>> print(mk_single_filter_body("scale", "600", "400"))
     scale=600:400
-    >>> print(_mk_single_filter_body("concat"))
+    >>> print(mk_single_filter_body("concat"))
     concat
     """
     paras = _filter_defaults.get(name, {})
@@ -84,7 +85,7 @@ class Filter(object):
         
     def add_filter(self, name, *args, **kwargs):
         self._filters.append(
-            _mk_single_filter_body(name, *args, **kwargs))
+            mk_single_filter_body(name, *args, **kwargs))
 
     def to_str(self):
         ilabs = self._labels_to_str(self.iv, self.ia)

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -146,7 +146,7 @@ class ConcatWithGapFilterGraphBuilder(object):
 
     def add_gap(self, duration):
         if duration <= 0:
-            return
+            return self
         self._result.append(
             self._tmpl_gapv[0].format(gapno=self._gapno, duration=duration))
         self._fconcat.iv.append(self._tmpl_gapv[1].format(gapno=self._gapno))
@@ -156,13 +156,20 @@ class ConcatWithGapFilterGraphBuilder(object):
         self._fconcat.ia.append(self._tmpl_gapa[1].format(gapno=self._gapno))
         self._gapno += 1
 
-    def add_body(self, stream_no, v_filter_extra, a_filter_extra):
+        return self
+
+    def add_video_content(self, stream_no, v_filter_extra):
         self._result.append(
             self._bodyv[0].format(
                 stream_no=stream_no,
                 bodyident=self._numbody,
                 v_filter_extra=v_filter_extra + "," if v_filter_extra else ""))
         self._fconcat.iv.append(self._bodyv[1].format(bodyident=self._numbody))
+        self._numbody += 1
+
+        return self
+
+    def add_audio_content(self, stream_no, a_filter_extra):
         self._result.append(
             self._bodya[0].format(
                 stream_no=stream_no,

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -11,6 +11,7 @@ import logging
 
 __all__ = [
     "Filter",
+    "ConcatWithGapFilterGraphBuilder",
     ]
 
 _logger = logging.getLogger(__name__)

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -144,13 +144,19 @@ class ConcatWithGapFilterGraphBuilder(object):
         self._gapno = 0
         self._numbody = 0
 
-    def add_gap(self, duration):
+    def add_video_gap(self, duration):
         if duration <= 0:
             return self
         self._result.append(
             self._tmpl_gapv[0].format(gapno=self._gapno, duration=duration))
         self._fconcat.iv.append(self._tmpl_gapv[1].format(gapno=self._gapno))
-        #
+        self._gapno += 1
+
+        return self
+
+    def add_audio_gap(self, duration):
+        if duration <= 0:
+            return self
         self._result.append(
             self._tmpl_gapa[0].format(gapno=self._gapno, duration=duration))
         self._fconcat.ia.append(self._tmpl_gapa[1].format(gapno=self._gapno))

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -1,0 +1,196 @@
+#! /bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module includes a helper for constructing the filter graph of ffmpeg.
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+from itertools import chain
+import logging
+
+__all__ = [
+    "Filter",
+    ]
+
+_logger = logging.getLogger(__name__)
+
+
+_filter_defaults = {
+    "color": {
+        "c": "black",
+        },
+    "sine": {
+        "frequency": "0",
+        },
+    }
+
+
+def _mk_single_filter_body(name, *args, **kwargs):
+    r"""
+    >>> print(_mk_single_filter_body("color", s="960x540", d="123.45"))
+    color=c=black:d=123.45:s=960x540
+    >>> print(_mk_single_filter_body("scale", "600", "400"))
+    scale=600:400
+    >>> print(_mk_single_filter_body("concat"))
+    concat
+    """
+    paras = _filter_defaults.get(name, {})
+    paras.update(**kwargs)
+
+    all_args = list(args)  # positional
+    all_args += [
+        "{}={}".format(k, paras[k])
+        for k in sorted(paras.keys())]
+
+    return "{}{}{}".format(
+        name,
+        "=" if all_args else "",
+        ":".join(all_args))
+
+
+class Filter(object):
+    """
+    >>> f = Filter()
+    >>> f.iv.append("[0:v]")
+    >>> f.add_filter("scale", "600", "400")
+    >>> f.add_filter("setsar", "1")
+    >>> f.ov.append("[v0]")
+    >>> print(f.to_str())
+    [0:v]scale=600:400,setsar=1[v0]
+    >>> #
+    >>> f = Filter()
+    >>> f.iv.append("[0:v]")
+    >>> f.iv.append("[1:v]")
+    >>> f.add_filter("concat")
+    >>> f.ov.append("[vc0]")
+    >>> print(f.to_str())
+    [0:v][1:v]concat[vc0]
+    """
+    def __init__(self):
+        self.iv = []  # the labels of input video streams
+        self.ia = []  # the labels of input audio streams
+        self._filters = []
+        self.ov = []  # the labels of output video streams
+        self.oa = []  # the labels of output audio streams
+
+    def _labels_to_str(self, v, a):
+        if not v and a:
+            v = [""] * len(a)
+        if not a and v:
+            a = [""] * len(v)
+        return "".join(chain.from_iterable(zip(v, a)))
+        
+    def add_filter(self, name, *args, **kwargs):
+        self._filters.append(
+            _mk_single_filter_body(name, *args, **kwargs))
+
+    def to_str(self):
+        ilabs = self._labels_to_str(self.iv, self.ia)
+        filterbody = ",".join(self._filters)
+        olabs = self._labels_to_str(self.ov, self.oa)
+        return ilabs + filterbody + olabs
+
+
+class ConcatWithGapFilterGraphBuilder(object):
+    def __init__(self, ident, w=960, h=540, sample_rate=44100):
+        self._ident = ident
+
+        # black video stream
+        fpadv = Filter()
+        fpadv.add_filter(
+            "color", s="%dx%d" % (w, h), d="{duration:.3f}")
+        fpadv.add_filter("setsar", "1")
+        fpadv.ov.append("[gap{gapno}v%s]" % ident)
+        self._tmpl_gapv = (fpadv.to_str(), "".join(fpadv.ov))
+
+        # silence left; silence right; -> amerge
+        fpada = [Filter(), Filter(), Filter()]
+        nch = 2
+        for i in range(nch):
+            fpada[i].add_filter(
+                "sine", sample_rate="%d" % sample_rate,
+                d="{duration:.3f}")
+            olab = "[gap{{gapno}}a_c{i}_{ident}]".format(ident=ident, i=i)
+            fpada[i].oa.append(olab)
+            fpada[-1].iv.append(olab)
+        fpada[-1].add_filter("amerge", "%d" % len(fpada[-1].iv))
+        fpada[-1].oa.append("[gap{{gapno}}a{ident}]".format(ident=ident))
+        self._tmpl_gapa = (
+            ";\n".join([fpada[i].to_str()
+                        for i in range(len(fpada))]),
+            "".join(fpada[-1].oa))
+
+        # filter to original video stream
+        fbodyv = Filter()
+        fbodyv.iv.append("[{stream_no}:v]")
+        fbodyv.add_filter("{v_filter_extra}scale", "%d" % w, "%d" % h)
+        fbodyv.add_filter("setsar", "1")
+        fbodyv.ov.append("[v%s_{bodyident}]" % ident)
+        self._bodyv = (fbodyv.to_str(), "".join(fbodyv.ov))
+
+        # filter to original audio stream
+        fbodya = Filter()
+        fbodya.ia.append("[{stream_no}:a]")
+        fbodya.add_filter(
+            "{a_filter_extra}aresample", "%d" % sample_rate)
+        fbodya.oa.append("[a%s_{bodyident}]" % ident)
+        self._bodya = (fbodya.to_str(), "".join(fbodya.oa))
+
+        #
+        self._result = []
+        self._fconcat = Filter()
+        self._gapno = 0
+        self._numbody = 0
+
+    def add_gap(self, duration):
+        if duration <= 0:
+            return
+        self._result.append(
+            self._tmpl_gapv[0].format(gapno=self._gapno, duration=duration))
+        self._fconcat.iv.append(self._tmpl_gapv[1].format(gapno=self._gapno))
+        #
+        self._result.append(
+            self._tmpl_gapa[0].format(gapno=self._gapno, duration=duration))
+        self._fconcat.ia.append(self._tmpl_gapa[1].format(gapno=self._gapno))
+        self._gapno += 1
+
+    def add_body(self, stream_no, v_filter_extra, a_filter_extra):
+        self._result.append(
+            self._bodyv[0].format(
+                stream_no=stream_no,
+                bodyident=self._numbody,
+                v_filter_extra=v_filter_extra + "," if v_filter_extra else ""))
+        self._fconcat.iv.append(self._bodyv[1].format(bodyident=self._numbody))
+        self._result.append(
+            self._bodya[0].format(
+                stream_no=stream_no,
+                bodyident=self._numbody,
+                a_filter_extra=a_filter_extra + "," if a_filter_extra else ""))
+        self._fconcat.ia.append(self._bodya[1].format(bodyident=self._numbody))
+        self._numbody += 1
+
+        return self
+
+    def build(self):
+        if len(self._fconcat.iv) > 1:
+            self._fconcat.add_filter(
+                "concat",
+                n="%d" % len(self._fconcat.iv), v="1", a="1")
+            self._fconcat.ov.append("[vc%s]" % self._ident)
+            self._fconcat.oa.append("[ac%s]" % self._ident)
+            self._result.append(self._fconcat.to_str())
+        else:
+            self._fconcat.ov.extend(self._fconcat.iv)
+            self._fconcat.oa.extend(self._fconcat.ia)
+        #
+        return (
+            ";\n".join(self._result),
+            self._fconcat.ov[0],
+            self._fconcat.oa[0])
+
+
+#
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -37,7 +37,8 @@ class _StackVideosFilterGraphBuilder(object):
 
     def set_paddings(self, idx, pre, post, v_filter_extra, a_filter_extra):
         self._builders[idx].add_gap(pre)
-        self._builders[idx].add_body(idx, v_filter_extra, a_filter_extra)
+        self._builders[idx].add_video_content(idx, v_filter_extra)
+        self._builders[idx].add_audio_content(idx, a_filter_extra)
         self._builders[idx].add_gap(post)
 
     def build_each_streams(self):

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -36,10 +36,12 @@ class _StackVideosFilterGraphBuilder(object):
                 ConcatWithGapFilterGraphBuilder(i, w, h, sample_rate))
 
     def set_paddings(self, idx, pre, post, v_filter_extra, a_filter_extra):
-        self._builders[idx].add_gap(pre)
+        self._builders[idx].add_video_gap(pre)
+        self._builders[idx].add_audio_gap(pre)
         self._builders[idx].add_video_content(idx, v_filter_extra)
         self._builders[idx].add_audio_content(idx, a_filter_extra)
-        self._builders[idx].add_gap(post)
+        self._builders[idx].add_video_gap(post)
+        self._builders[idx].add_audio_gap(post)
 
     def build_each_streams(self):
         result = []

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -132,9 +132,8 @@ def _build(args):
     #
     b = _StackVideosFilterGraphBuilder(
         shape=shape, w=args.w, h=args.h, sample_rate=args.sample_rate)
-    with SyncDetector(
-        max_misalignment=args.max_misalignment) as det:
-        for i, inf in enumerate(det.align(files)):
+    with SyncDetector() as det:
+        for i, inf in enumerate(det.align(files, max_misalignment=args.max_misalignment)):
             pre, post = inf[1]["pad"], inf[1]["pad_post"]
             if not (pre > 0 and post > 0):
                 # FIXME:

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -22,6 +22,7 @@ import numpy as np
 from align_videos_by_soundtrack.align import SyncDetector
 from align_videos_by_soundtrack.communicate import check_call
 from .ffmpeg_filter_graph import Filter, ConcatWithGapFilterGraphBuilder
+from .utils import check_and_decode_filenames
 
 
 _logger = logging.getLogger(__name__)
@@ -120,7 +121,10 @@ pan=stereo|\\
 
 def _build(args):
     shape = json.loads(args.shape) if args.shape else (2, 2)
-    files = list(map(os.path.abspath, args.files))
+    files = check_and_decode_filenames(args.files)
+    if not files:
+        sys.exit(1)
+
     if len(files) < shape[0] * shape[1]:
         files = files + [files[i % len(files)]
                          for i in range(shape[0] * shape[1] - len(files))]
@@ -236,7 +240,7 @@ See the help of alignment_info_by_sound_track. (default: %(default)d)""")
         ]
     args = parser.parse_args(args[1:])
     logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
-
+    
     files, fc, maps = _build(args)
     if args.mode == "script_bash":
         print("""\

--- a/align_videos_by_soundtrack/trim.py
+++ b/align_videos_by_soundtrack/trim.py
@@ -35,8 +35,8 @@ See the help of alignment_info_by_sound_track.""")
     import os
     if not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
-    with SyncDetector(max_misalignment=args.max_misalignment) as sd:
-        infos = sd.align(args.files)
+    with SyncDetector() as sd:
+        infos = sd.align(args.files, max_misalignment=args.max_misalignment)
 
         for fn, editinfo in infos:
             start_offset = editinfo["trim"]

--- a/align_videos_by_soundtrack/utils.py
+++ b/align_videos_by_soundtrack/utils.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+"""
+This module contains tiny extra helpers.
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import sys
+import os
+import logging
+
+
+__all__ = [
+    "check_and_decode_filenames",
+    ]
+
+_logger = logging.getLogger(__name__)
+
+
+if hasattr("", "decode"):  # python 2
+    def _decode(s):
+        return s.decode(sys.stdout.encoding)
+else:
+    def _decode(s):
+        return s
+
+
+def check_and_decode_filenames(files):
+    result = list(map(_decode, map(os.path.abspath, files)))
+    nf_files = [path for path in result if not os.path.isfile(path)]
+    if nf_files:
+        for nf in nf_files:
+            _logger.error("{}: No such file.".format(nf))
+        return []
+    return result
+
+
+if __name__ == '__main__':
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
Regarding to [this](https://github.com/jeorgen/align-videos-by-sound/pull/18#issuecomment-401807870), I'm planning `concat_videos_by_sound_track`. 

For a concert movie, it is assumed that there is one movie that shoots the whole event and a movie divided into two by stopping shooting (or cutting by editing) once.  It is a script that combines the latter with filling the gap, based on the former sound tracks.

Because of this, it became necessary to slightly generalize the processing described in simple_stack_videos.py. Extension is necessary also for get_media_info, because the script to be created needs to know the size of input media. (BTW, `ConcatWithGapFilterGraphBuilder` can be used not only my present purpose, but also more simple "padding to video".)

The coding of `concat_videos_by_sound_track` takes a little time, so I decided to make it PR first.