### PR TITLE
concat_videos_by_sound_track

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This script combines the latter with filling the gap, based on the former sound 
 
 Usage:
 
-    concat_videos_by_sound_track <base> <divided1> <divided2> [<divided1>…]
+    concat_videos_by_sound_track <base> <divided1> <divided2> [<divided3>…]
 
 Audio-only media may be passed to "base". For now, except for "base", both video stream
 and audio stream must be included.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ cd align-videos-by-sound
 python setup.py install
 ```
 
-After that, you can use this package as python module, or some sample application scripts (`alignment_info_by_sound_track`,  and`simple_stack_videos_by_sound_track`).
+After that, you can use this package as python module, or some sample application scripts (`alignment_info_by_sound_track`, `simple_stack_videos_by_sound_track`, etc).
 
 ## Scripts:
 ### alignment_info_by_sound_track
@@ -73,3 +73,19 @@ Usage:
 
 See `simple_stack_videos_by_sound_track --help` for more details.
 
+
+### concat_videos_by_sound_track
+Regarding an event such as a certain concert, suppose that there is unedited media
+that shoots and records the whole, and on the other hand, there are multiple divided
+media such as stop recording halfway.
+
+This script combines the latter with filling the gap, based on the former sound tracks.
+
+Usage:
+
+    concat_videos_by_sound_track <base> <divided1> <divided2> [<divided1>…]
+
+Audio-only media may be passed to "base". For now, except for "base", both video stream
+and audio stream must be included.
+
+See `concat_videos_by_sound_track --help` for more details.

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -202,7 +202,7 @@ class SyncDetector(object):
         """
         # First, try finding delays roughly by passing low sample rate.
         pad_pre, trim_pre, orig_dur, strms_info, pad_post, trim_post = self._align(
-            44100 // 12, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
+            44100 // 4, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
             max_misalignment, known_delay_ge_map)
 
         # update knwown map, and max_misalignment
@@ -210,7 +210,7 @@ class SyncDetector(object):
             i: max(0.0, int(trim_pre[i] - 5.0))
             for i in range(len(trim_pre))
             }
-        max_misalignment = 15
+        max_misalignment = 30
 
         # Finally, try finding delays precicely
         pad_pre, trim_pre, orig_dur, strms_info, pad_post, trim_post = self._align(

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -103,7 +103,12 @@ def _build(args):
 def main(args=sys.argv):
     import argparse
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="""\
+For a concert movie, now, \
+there is one movie that shoots the whole event and a movie \
+divided into two by stopping shooting (or cutting by editing) \
+once. This script combines the latter with filling the gap, \
+based on the former sound tracks.""")
     parser.add_argument(
         "base",
         help="""\

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -21,14 +21,22 @@ from .ffmpeg_filter_graph import (
     Filter,
     ConcatWithGapFilterGraphBuilder,
     )
+from .utils import check_and_decode_filenames
 
 
 _logger = logging.getLogger(__name__)
 
 
 def _build(args):
-    base = args.base
-    targets = [args.splitted_earliest] + args.splitted
+    chk = check_and_decode_filenames([args.base])
+    if not chk:
+        sys.exit(1)
+    base = chk[0]
+
+    targets = check_and_decode_filenames([args.splitted_earliest] + args.splitted)
+    if not targets:
+        sys.exit(1)
+
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
 

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -1,0 +1,191 @@
+#! /bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module is intended as an example of one application of
+"align_videos_by_soundtrack.align". For a concert movie, now,
+there is one movie that shoots the whole event and a movie
+divided into two by stopping shooting (or cutting by editing)
+once. This script combines the latter with filling the gap,
+based on the former sound tracks.
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import sys
+import logging
+import json
+
+from align_videos_by_soundtrack.align import SyncDetector
+from align_videos_by_soundtrack.communicate import check_call
+from .ffmpeg_filter_graph import (
+    Filter,
+    ConcatWithGapFilterGraphBuilder,
+    )
+
+
+_logger = logging.getLogger(__name__)
+
+
+def _build(args):
+    base = args.base
+    targets = [args.splitted_earliest] + args.splitted
+    a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
+    v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
+
+    vf = lambda i: ",".join(filter(None, [v_filter_extra.get(""), v_filter_extra.get("%d" % i)]))
+    af = lambda i: ",".join(filter(None, [a_filter_extra.get(""), a_filter_extra.get("%d" % i)]))
+
+    gaps = []
+    prev_dur = 0.0
+    width, height = 0, 0
+    sample_rate = 0
+    base_has_video = None
+    with SyncDetector() as sd:
+        known_delay_ge_map = {0: 0}
+        for i in range(len(targets)):
+            res = sd.align(
+                [base, targets[i]],
+                known_delay_ge_map=known_delay_ge_map)
+            start = prev_dur - known_delay_ge_map[0]
+            gaps.append((start, res[1][1]["pad"] - start))
+            #
+            prev_dur = res[1][1]["orig_duration"]
+            known_delay_ge_map[0] = res[1][1]["trim"]
+
+            # detect resolution, etc.
+            if base_has_video is None:
+                ostrms_base = res[0][1]["orig_streams"]
+                base_has_video = any([st["type"] == "Video" for st in ostrms_base])
+            ostrms = res[1][1]["orig_streams"]
+            for st in ostrms:
+                if "resolution" in st:
+                    new_w, new_h = st["resolution"][0]
+                    width, height = max(width, new_w), max(height, new_h)
+                elif "sample_rate" in st:
+                    sample_rate = max(sample_rate, st["sample_rate"])
+
+    bld = ConcatWithGapFilterGraphBuilder("c", w=width, h=height, sample_rate=sample_rate)
+    for i in range(len(targets)):
+        start, gap = gaps[i]
+        if gap > 0:
+            if not base_has_video or args.video_gap == "black":
+                bld.add_video_gap(gap)
+            else:
+                fv = Filter()
+                fv.add_filter("trim", "%.3f" % start, "%.3f" % (start + gap))
+                fv.add_filter("setpts", "PTS-STARTPTS")
+                bld.add_video_content(0, ",".join(
+                        list(filter(None, [vf(0), fv.to_str()]))))
+            #
+            if args.audio_gap == "silence":
+                bld.add_audio_gap(gap)
+            else:
+                fa = Filter()
+                fa.add_filter("atrim", "%.3f" % start, "%.3f" % (start + gap))
+                fa.add_filter("asetpts", "PTS-STARTPTS")
+                bld.add_audio_content(0, ",".join(
+                        list(filter(None, [af(0), fa.to_str()]))))
+        bld.add_video_content(i + 1, vf(i + 1))
+        bld.add_audio_content(i + 1, af(i + 1))
+    fc, vmap, amap = bld.build()
+    return [args.base] + targets, fc, vmap, amap
+
+
+def main(args=sys.argv):
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "base",
+        help="""\
+The media file which contains at least audio, \
+which becomes a base of synchronization of files to be concatinated.""")
+    parser.add_argument(
+        "splitted_earliest",
+        help="""First video to be concatinated. \
+Currently, both video stream and audio stream must be included.""")
+    parser.add_argument(
+        "splitted", nargs="+",
+        help="""\
+Videos to be concatinated. Arrange them in chronological order. \
+When concatenating, if there is a gap which is detected by the "base" audio, \
+this script fills it. However, even if there is overlap, \
+this script does not complain anything, but it goes without \
+saying that it's a "strange" movie. Currently, both video stream and audio \
+stream must be included.""")
+    parser.add_argument(
+        "-o", "--outfile", dest="outfile", default="concatenated.mp4",
+        help="Specifying the output file. (default: %(default)s)")
+    parser.add_argument(
+        '--mode', choices=['script_bash', 'direct'], default='script_bash',
+        help="""\
+Switching whether to produce bash shellscript or to call ffmpeg directly. (default: %(default)s)""")
+    #
+    #####
+    parser.add_argument(
+        '--audio_gap', choices=['silence', 'base'], default='base',
+        help="""\
+Switching whether to use no audio or to use base audio as gap. (default: %(default)s)""")
+    #
+    parser.add_argument(
+        '--a_filter_extra', type=str,
+        help="""\
+Filter to add to the audio input stream. Pass in JSON format, in dictionary format \
+(stream by key, filter by value). For example, '{"1": "volume = 0.5", "2": "loudnorm"}' etc. \
+The key "0" is of base audio media. \
+If the key is blank, it means all input streams. Only single input / single output \
+filters can be used.""")
+    ###
+    parser.add_argument(
+        '--video_gap', choices=['black', 'base'], default='base',
+        help="""\
+Switching whether to use no video or to use base video as gap. (default: %(default)s)""")
+    #
+    parser.add_argument(
+        '--v_filter_extra', type=str,
+        help="""\
+Filter to add to the video input stream. Pass in JSON format, in dictionary format \
+(stream by key, filter by value). For example, '{"1": "boxblur=luma_radius=2:luma_power=1"}' etc. \
+The key "0" is of base audio media. \
+If the key is blank, it means all input streams. Only single input / single output \
+filters can be used.""")
+    #####
+    args = parser.parse_args(args[1:])
+    logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
+
+    extra_ffargs = [
+        "-color_primaries", "bt709", "-color_trc", "bt709", "-colorspace", "bt709"
+        ]
+    files, fc, vmap, amap = _build(args)
+    maps = [vmap, amap]
+    if args.mode == "script_bash":
+        print("""\
+#! /bin/sh
+
+ffmpeg -y \\
+  {} \\
+  -filter_complex "
+{}
+" {} \\
+  {} \\
+  "{}"
+""".format(" ".join(['-i "{}"'.format(f) for f in files]),
+           fc,
+           " ".join(["-map '%s'" % m for m in maps]),
+           " ".join(extra_ffargs),
+           args.outfile))
+    else:
+        cmd = ["ffmpeg", "-y"]
+        for fn in files:
+            cmd.extend(["-i", fn])
+        cmd.extend(["-filter_complex", fc])
+        for m in maps:
+            cmd.extend(["-map", m])
+        cmd.extend(extra_ffargs)
+        cmd.append(args.outfile)
+
+        check_call(cmd)
+
+#
+if __name__ == '__main__':
+    main()

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -16,8 +16,8 @@ import logging
 import json
 from itertools import chain
 
-from align_videos_by_soundtrack.align import SyncDetector
-from align_videos_by_soundtrack.communicate import check_call
+from .align import SyncDetector
+from .communicate import check_call
 from .ffmpeg_filter_graph import (
     Filter,
     ConcatWithGapFilterGraphBuilder,

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -45,21 +45,15 @@ def _build(args):
     af = lambda i: ",".join(filter(None, [a_filter_extra.get(""), a_filter_extra.get("%d" % i)]))
 
     gaps = []
-    prev_dur = 0.0
     width, height = 0, 0
     sample_rate = 0
     base_has_video = None
+    start = 0
     with SyncDetector() as sd:
-        known_delay_ge_map = {0: 0}
         for i in range(len(targets)):
-            res = sd.align(
-                [base, targets[i]],
-                known_delay_ge_map=known_delay_ge_map)
-            start = prev_dur - known_delay_ge_map[0]
-            gaps.append((start, res[1][1]["pad"] - start))
-            #
-            prev_dur = res[1][1]["orig_duration"]
-            known_delay_ge_map[0] = res[1][1]["trim"]
+            res = sd.align([base, targets[i]])
+            gaps.append((start, res[0][1]["trim"] - start))
+            start = res[0][1]["trim"] + (res[1][1]["orig_duration"] - res[1][1]["trim"])
 
             # detect resolution, etc.
             if base_has_video is None:

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -91,7 +91,7 @@ def _build(args):
         bld.add_video_content(i + 1, vf(i + 1))
         bld.add_audio_content(i + 1, af(i + 1))
     fc, vmap, amap = bld.build()
-    return [args.base] + targets, fc, vmap, amap
+    return [base] + targets, fc, vmap, amap
 
 
 def main(args=sys.argv):

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -182,7 +182,13 @@ def _build(args):
 def main(args=sys.argv):
     import argparse
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description="""\
+Suppose that a certain concert is shot by multiple people from multiple angles. \
+In most cases, shooting start and shooting end time have individual differences. \
+This program combines movies of multiple angles in a tile shape with "hstack" and "vstack", \
+based on sound track synchronization. Although it is a program for the main object \
+to arrange tile-like and simultaneous playback, it is possible to do a little \
+different thing from this. See the option description.""")
     parser.add_argument(
         "files", nargs="+",
         help="The media files which contains both video and audio.")
@@ -195,7 +201,7 @@ def main(args=sys.argv):
 Switching whether to produce bash shellscript or to call ffmpeg directly. (default: %(default)s)""")
     #####
     parser.add_argument(
-        '--audio_mode', choices=['amerge', 'multi_streams'], default='amerge',
+        '--audio_mode', choices=['amerge', 'multi_streams', 'individual'], default='amerge',
         help="""\
 Switching whether to merge audios or to keep each as multi streams, or \
 to pad each into the corresponding indivisual output file. --audio_mode='indivisual' \

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ import os.path
 try:
     from setuptools import setup
 except ImportError:
+    # TODO: Decide whether to force "setuptools" or even to users
+    #       with "distutils" only.
     from distutils.core import setup
     extra = {'scripts': [
             "bin/alignment_info_by_sound_track",
@@ -17,6 +19,7 @@ else:
         'entry_points': {
             'console_scripts': [
                 'alignment_info_by_sound_track = align_videos_by_soundtrack.align:main',
+                'concat_videos_by_sound_track = align_videos_by_soundtrack.concat:main',
                 'simple_stack_videos_by_sound_track = align_videos_by_soundtrack.simple_stack_videos:main',
                 'trim_by_sound_track = align_videos_by_soundtrack.trim:main',
                 ],


### PR DESCRIPTION
* New script: concat_videos_by_sound_track
* New mode of simple_stack_videos_by_sound_track: `individual`

The former is what I already announced. What I really wanted was "to find edit points". Because I can not do this, it will happen that `simple_stack_videos_by_sound_track` will not notice that it is making "funny videos" for a long time before finishing processing . Eventually I gave up it, at the very least, if the video has already been split at the editing point by other means, I wanted a tool to create a concatanated video in which the sound was connected properly.

Although the latter is a substitute for just padding insertion, the interface is unnatural, and ordinary users will not notice :)