### PR TITLE
--v_extra_ffargs, --a_extra_ffargs, etc.

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -269,12 +269,12 @@ def main(args=sys.argv):
     parser = argparse.ArgumentParser(prog=args[0], usage=_doc_template)
     parser.add_argument(
         '--max_misalignment',
-        type=float, default=10*60,
+        type=str, default="600",
         help='When handling media files with long playback time, \
 it may take a huge amount of time and huge memory. \
 In such a case, by changing this value to a small value, \
 it is possible to indicate the scanning range of the media file to the program. \
-(default: %(default)d)')
+(default: %(default)s)')
     parser.add_argument(
         '--known_delay_ge_map',
         type=str,
@@ -339,7 +339,7 @@ It is possible to pass any media that ffmpeg can handle.',)
         dont_cache=args.dont_cache) as det:
         result = det.align(
             file_specs,
-            max_misalignment=args.max_misalignment,
+            max_misalignment=communicate.parse_time(args.max_misalignment),
             known_delay_ge_map=known_delay_ge_map)
     if args.json:
         print(json.dumps({'edit_list': result}, indent=4))

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -210,7 +210,8 @@ class SyncDetector(object):
         trim_pre = -(pad_pre - pad_pre.max())
         infos = [self._get_media_info(fn) for fn in files]
         orig_dur = np.array([inf["duration"] for inf in infos])
-        strms_info = [inf["streams"] for inf in infos]
+        strms_info = [
+            (inf["streams"], inf["streams_summary"]) for inf in infos]
         pad_post = list(
             (pad_pre + orig_dur).max() - (pad_pre + orig_dur))
         trim_post = list(
@@ -241,7 +242,6 @@ class SyncDetector(object):
             self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
             max_misalignment, known_delay_ge_map)
 
-        #
         return [
             [
                 files[i],
@@ -251,7 +251,8 @@ class SyncDetector(object):
                     "orig_duration": orig_dur[i],
                     "trim_post": trim_post[i],
                     "pad_post": pad_post[i],
-                    "orig_streams": strms_info[i],
+                    "orig_streams": strms_info[i][0],
+                    "orig_streams_summary": strms_info[i][1],
                     }
                 ]
             for i in range(len(files))]

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -325,12 +325,8 @@ It is possible to pass any media that ffmpeg can handle.',)
         stream=sys.stderr,
         format="%(created)f|%(levelname)5s:%(module)s#%(funcName)s:%(message)s")
 
-    file_specs = []
-    if args.file_names and len(args.file_names) >= 2:
-        file_specs = check_and_decode_filenames(args.file_names)
-        # _logger.debug(file_specs)
-    else:  # No pipe and no input file, print help text and exit
-        _bailout(parser)
+    file_specs = check_and_decode_filenames(
+        args.file_names, min_num_files=2)
     if not file_specs:
         _bailout(parser)
 

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -40,6 +40,21 @@ else:
 # low-level APIs
 #
 
+class pipes_quote(object):
+    def __init__(self, needs_to_quote=True):
+        self._needs_to_quote = needs_to_quote
+
+    def __call__(self, s):
+        if self._needs_to_quote:
+            import pipes
+            return pipes.quote(s)
+        return s
+
+    def map(self, iterable):
+        for iter in iterable:
+            yield self.__call__(iter)
+
+        
 def _filter_args(*cmd):
     """
     do filtering None, and do encoding items to bytes

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -32,14 +32,10 @@ _logger = logging.getLogger(__name__)
 
 
 def _build(args):
-    chk = check_and_decode_filenames([args.base])
-    if not chk:
-        sys.exit(1)
-    base = chk[0]
-
-    targets = check_and_decode_filenames(args.splitted)
-    if not targets:
-        sys.exit(1)
+    base = check_and_decode_filenames(
+        [args.base], exit_if_error=True)[0]
+    targets = check_and_decode_filenames(
+        args.splitted, min_num_files=2, exit_if_error=True)
 
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
@@ -202,9 +198,6 @@ If you hate this behaviour, specify this option.''' % (
             _cache.cache_root_dir))
     #####
     args = parser.parse_args(args[1:])
-    if len(args.splitted) < 2:
-        parser.print_usage()
-        sys.exit(1)
     logging.basicConfig(
         level=logging.DEBUG,
         stream=sys.stderr,

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -65,14 +65,11 @@ def _build(args):
     has_video = []
     for i in range(len(einf)):
         # detect resolution, etc.
-        ostrms = einf[i]["orig_streams"]
-        has_video.append(any([st["type"] == "Video" for st in ostrms]))
-        for st in ostrms:
-            if "resolution" in st:
-                new_w, new_h = st["resolution"][0]
-                width, height = max(width, new_w), max(height, new_h)
-            elif "sample_rate" in st:
-                sample_rate = max(sample_rate, st["sample_rate"])
+        summary = einf[i]["orig_streams_summary"]
+        has_video.append(summary["num_video_streams"] > 0)
+        width = max(width, summary["max_resol_width"])
+        height = max(height, summary["max_resol_height"])
+        sample_rate = max(sample_rate, summary["max_sample_rate"])
 
     targets_have_video = any(has_video[1:])
     bld = ConcatWithGapFilterGraphBuilder("c", w=width, h=height, sample_rate=sample_rate)

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from itertools import chain
+from collections import defaultdict
 import logging
 
 __all__ = [
@@ -53,6 +54,9 @@ def mk_single_filter_body(name, *args, **kwargs):
         ":".join(all_args))
 
 
+_olab_counter = defaultdict(int)
+
+
 class Filter(object):
     """
     >>> f = Filter()
@@ -70,6 +74,22 @@ class Filter(object):
     >>> f.ov.append("[vc0]")
     >>> print(f.to_str())
     [0:v][1:v]concat[vc0]
+    >>> #
+    >>> f = Filter()
+    >>> f.iv.append("[0:v]")
+    >>> f.iv.append("[1:v]")
+    >>> f.add_filter("concat")
+    >>> f.append_outlabel_v()
+    >>> print(f.to_str())
+    [0:v][1:v]concat[v1]
+    >>> #
+    >>> f = Filter()
+    >>> f.ia.append("[0:a]")
+    >>> f.ia.append("[1:a]")
+    >>> f.add_filter("concat")
+    >>> f.append_outlabel_a()
+    >>> print(f.to_str())
+    [0:a][1:a]concat[a1]
     """
     def __init__(self):
         self.iv = []  # the labels of input video streams
@@ -92,6 +112,18 @@ class Filter(object):
     def insert_filter(self, i, name, *args, **kwargs):
         self._filters.insert(
             i, mk_single_filter_body(name, *args, **kwargs))
+
+    def append_outlabel_v(self, templ="[v%(counter)d]"):
+        global _olab_counter
+        _olab_counter[templ] += 1
+        self.ov.append(templ % dict(
+                counter=_olab_counter[templ]))
+
+    def append_outlabel_a(self, templ="[a%(counter)d]"):
+        global _olab_counter
+        _olab_counter[templ] += 1
+        self.oa.append(templ % dict(
+                counter=_olab_counter[templ]))
 
     def to_str(self):
         ilabs = self._labels_to_str(self.iv, self.ia)

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -89,6 +89,10 @@ class Filter(object):
         self._filters.append(
             mk_single_filter_body(name, *args, **kwargs))
 
+    def insert_filter(self, i, name, *args, **kwargs):
+        self._filters.insert(
+            i, mk_single_filter_body(name, *args, **kwargs))
+
     def to_str(self):
         ilabs = self._labels_to_str(self.iv, self.ia)
         filterbody = ",".join(self._filters)

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -34,13 +34,15 @@ def mk_single_filter_body(name, *args, **kwargs):
     color=c=black:d=123.45:s=960x540
     >>> print(mk_single_filter_body("scale", "600", "400"))
     scale=600:400
+    >>> print(mk_single_filter_body("scale", 600, 400))
+    scale=600:400
     >>> print(mk_single_filter_body("concat"))
     concat
     """
     paras = _filter_defaults.get(name, {})
     paras.update(**kwargs)
 
-    all_args = list(args)  # positional
+    all_args = list(map(lambda a: "%s" % a, args))  # positional
     all_args += [
         "{}={}".format(k, paras[k])
         for k in sorted(paras.keys())]
@@ -116,7 +118,7 @@ class ConcatWithGapFilterGraphBuilder(object):
             olab = "[gap{{gapno}}a_c{i}_{ident}]".format(ident=ident, i=i)
             fpada[i].oa.append(olab)
             fpada[-1].iv.append(olab)
-        fpada[-1].add_filter("amerge", "%d" % len(fpada[-1].iv))
+        fpada[-1].add_filter("amerge", len(fpada[-1].iv))
         fpada[-1].oa.append("[gap{{gapno}}a{ident}]".format(ident=ident))
         self._tmpl_gapa = (
             ";\n".join([fpada[i].to_str()
@@ -126,7 +128,7 @@ class ConcatWithGapFilterGraphBuilder(object):
         # filter to original video stream
         fbodyv = Filter()
         fbodyv.iv.append("[{stream_no}:v]")
-        fbodyv.add_filter("{v_filter_extra}scale", "%d" % w, "%d" % h)
+        fbodyv.add_filter("{v_filter_extra}scale", w, h)
         fbodyv.add_filter("setsar", "1")
         fbodyv.ov.append("[v%s_{bodyident}]" % ident)
         self._bodyv = (fbodyv.to_str(), "".join(fbodyv.ov))
@@ -135,7 +137,7 @@ class ConcatWithGapFilterGraphBuilder(object):
         fbodya = Filter()
         fbodya.ia.append("[{stream_no}:a]")
         fbodya.add_filter(
-            "{a_filter_extra}aresample", "%d" % sample_rate)
+            "{a_filter_extra}aresample", sample_rate)
         fbodya.oa.append("[a%s_{bodyident}]" % ident)
         self._bodya = (fbodya.to_str(), "".join(fbodya.oa))
 
@@ -195,7 +197,7 @@ class ConcatWithGapFilterGraphBuilder(object):
             raise Exception("You haven't prepared to call this method.")
         self._fconcat.add_filter(
             "concat",
-            n="%d" % max(niv, nia),
+            n=max(niv, nia),
             v="1" if niv > 1 else "0",
             a="1" if nia > 1 else "0")
         if niv > 1:

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -71,7 +71,7 @@ class _StackVideosFilterGraphBuilder(object):
                         i * self._shape[0]:(i + 1) * self._shape[0]])
                 fhstack.add_filter(
                     "hstack",
-                    inputs="%d" % inputs,
+                    inputs=inputs,
                     shortest="1")
                 olab = "[{}v]".format("%d" % (i + 1) if self._shape[1] > 1 else "")
                 fhstack.ov.append(olab)
@@ -84,7 +84,7 @@ class _StackVideosFilterGraphBuilder(object):
         if self._shape[1] > 1:
             # vstack
             fvstack.add_filter(
-                "vstack", inputs="%d" % self._shape[1], shortest="1")
+                "vstack", inputs=self._shape[1], shortest="1")
             fvstack.ov.append("[v]")
             result.append(fvstack.to_str())
 

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -123,10 +123,9 @@ pan=stereo|\\
 
 def _build(args):
     shape = json.loads(args.shape) if args.shape else (2, 2)
-    files = check_and_decode_filenames(args.files)
-    if not files:
-        sys.exit(1)
-
+    files = check_and_decode_filenames(
+        args.files,
+        min_num_files=2, exit_if_error=True)
     if len(files) < shape[0] * shape[1]:
         files = files + [files[i % len(files)]
                          for i in range(shape[0] * shape[1] - len(files))]

--- a/align_videos_by_soundtrack/utils.py
+++ b/align_videos_by_soundtrack/utils.py
@@ -28,13 +28,27 @@ else:
         return s
 
 
-def check_and_decode_filenames(files):
+def check_and_decode_filenames(
+    files,
+    min_num_files=0,
+    exit_if_error=False):
+
     result = list(map(_decode, map(os.path.abspath, files)))
     nf_files = [path for path in result if not os.path.isfile(path)]
     if nf_files:
         for nf in nf_files:
             _logger.error("{}: No such file.".format(nf))
+        if exit_if_error:
+            sys.exit(1)
         return []
+    if min_num_files and len(result) < min_num_files:
+        _logger.error(
+            "At least {} files are necessary.".format(
+                min_num_files))
+        if exit_if_error:
+            sys.exit(1)
+        return []
+
     return result
 
 

--- a/align_videos_by_soundtrack/utils.py
+++ b/align_videos_by_soundtrack/utils.py
@@ -20,7 +20,9 @@ _logger = logging.getLogger(__name__)
 
 if hasattr("", "decode"):  # python 2
     def _decode(s):
-        return s.decode(sys.stdout.encoding)
+        if isinstance(s, (str,)):  # bytes in python 2
+            return s.decode(sys.stdout.encoding)
+        return s
 else:
     def _decode(s):
         return s


### PR DESCRIPTION
Essentially, modifications that change the behavior of an application are only two things: making it possible to pass a string to max_misalignment, and fixing the mistakes in using bt 709 related options. Regarding the latter, it is also an error that original used it unconditionally, so I made it possible for users to control by themselves `-v_extra_ffargs`, and `-a_extra_ffargs`.

All other remodeling is merely a cleanup. However, now I am writing another application called `simple_compile_videos_by_sound_track`, which needs those to write it. Not only for `simple_compile_videos_by_sound_track` but also because it is not easy to create an application yet, a smarter mechanism is necessary.

Regarding `simple_compile_videos_by_sound_track`, I have already completed things that I do not have problematic to use, but since it has become a dirty program, I intend to show it after refining a bit more.