### PR TITLE
withdrew the remodeling done in  PR#14, and remodeling "known_delay_ge_map", etc.

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -216,10 +216,7 @@ class SyncDetector(object):
                 ftds[ib], ftds[it],
                 kdm.get("min", float("nan")) * samps_per_sec,
                 kdm.get("max", float("nan")) * samps_per_sec)
-            if ib < it:
-                _result1[(ib, it)] = -delay / samps_per_sec
-            else:
-                _result1[(it, ib)] = delay / samps_per_sec
+            _result1[(ib, it)] = -delay / samps_per_sec
         #
         _result2[(0, 0)] = 0.0
         for i in range(len(files) - 1):
@@ -238,10 +235,11 @@ class SyncDetector(object):
         # _______________^^^^^^[0, 2] must be calculated by [0, 1], and [1, 2]
         # _______________^^^^^^^^[0, 3] must be calculated by [0, 2], and [2, 3]
         for ib, it in sorted(_result1.keys()):
-            if ib > 0:
-                for i in range(len(files) - 1):
-                    if it == i + 1:
-                        _result2[(0, i + 1)] = _result2[(0, ib)] + _result1[(ib, it)]
+            for i in range(len(files) - 1):
+                if ib > 0 and it == i + 1 and (0, i + 1) not in _result1 and (i + 1, 0) not in _result1:
+                    _result2[(0, it)] = _result2[(0, ib)] - _result1[(ib, it)]
+                elif it > 0 and ib == i + 1 and (0, i + 1) not in _result1 and (i + 1, 0) not in _result1:
+                    _result2[(0, ib)] = _result2[(0, it)] + _result1[(ib, it)]
 
         # build result
         result = np.array([_result2[k] for k in sorted(_result2.keys())])

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -216,19 +216,6 @@ class SyncDetector(object):
         """
         Find time delays between video files
         """
-        # First, try finding delays roughly by passing low sample rate.
-        pad_pre, trim_pre = self._align(
-            44100 // 4, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
-            max_misalignment, known_delay_ge_map)
-
-        # update knwown map, and max_misalignment
-        known_delay_ge_map = {
-            i: max(0.0, int(trim_pre[i] - 5.0))
-            for i in range(len(trim_pre))
-            }
-        max_misalignment = 30
-
-        # Finally, try finding delays precicely
         pad_pre, trim_pre = self._align(
             self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
             max_misalignment, known_delay_ge_map)
@@ -306,7 +293,7 @@ def main(args=sys.argv):
     parser = argparse.ArgumentParser(prog=args[0], usage=_doc_template)
     parser.add_argument(
         '--max_misalignment',
-        type=str, default="600",
+        type=str, default="1200",
         help='When handling media files with long playback time, \
 it may take a huge amount of time and huge memory. \
 In such a case, by changing this value to a small value, \

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -211,6 +211,20 @@ class SyncDetector(object):
         #
         return pad_pre, trim_pre
 
+    def get_media_info(self, files):
+        """
+        Get information about the media (by calling ffprobe).
+
+        Originally the "align" method had been internally acquired to get
+        "pad_post" etc. When trying to implement editing processing of a
+        real movie, it is very frequent to want to know these information
+        (especially duration) in advance. Therefore we decided to release
+        this as a method of this class. Since the retrieved result is held
+        in the instance variable of class, there is no need to worry about
+        performance.
+        """
+        return [self._get_media_info(fn) for fn in files]
+
     def align(self, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, samples_per_box=7,
               max_misalignment=0, known_delay_ge_map={}):
         """
@@ -220,7 +234,7 @@ class SyncDetector(object):
             self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
             max_misalignment, known_delay_ge_map)
         #
-        infos = [self._get_media_info(fn) for fn in files]
+        infos = self.get_media_info(files)
         orig_dur = np.array([inf["duration"] for inf in infos])
         strms_info = [
             (inf["streams"], inf["streams_summary"]) for inf in infos]

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -29,6 +29,7 @@ It reports back the offset. Example:
 import os
 import sys
 from collections import defaultdict
+import math
 import tempfile
 import shutil
 import logging
@@ -80,7 +81,11 @@ def _mk_freq_trans_summary(data, fft_bin_size, overlap, box_height, box_width, m
     return freqs_dict
 
 
-def _find_delay(freqs_dict_orig, freqs_dict_sample):
+def _find_delay(
+    freqs_dict_orig, freqs_dict_sample,
+    min_delay=float('nan'),
+    max_delay=float('nan')):
+    #
     keys = set(freqs_dict_sample.keys()) & set(freqs_dict_orig.keys())
     #
     if not keys:
@@ -93,7 +98,10 @@ def _find_delay(freqs_dict_orig, freqs_dict_sample):
         for x_i in freqs_dict_sample[key]:  # determine time offset
             for x_j in freqs_dict_orig[key]:
                 delta_t = x_i - x_j
-                t_diffs[delta_t] += 1
+                mincond_ok = math.isnan(min_delay) or delta_t >= min_delay
+                maxcond_ok = math.isnan(max_delay) or delta_t <= max_delay
+                inc = 1 if mincond_ok and maxcond_ok else 0
+                t_diffs[delta_t] += inc
 
     t_diffs_sorted = sorted(list(t_diffs.items()), key=lambda x: x[1])
     # _logger.debug(t_diffs_sorted)
@@ -123,7 +131,7 @@ class SyncDetector(object):
                 retry -= 1
                 time.sleep(1)
 
-    def _extract_audio(self, sample_rate, video_file, starttime_offset, duration):
+    def _extract_audio(self, sample_rate, video_file, duration):
         """
         Extract audio from video file, save as wav auido file
 
@@ -132,7 +140,6 @@ class SyncDetector(object):
         """
         return communicate.media_to_mono_wave(
             video_file, self._working_dir,
-            starttime_offset=starttime_offset,
             duration=duration,
             sample_rate=sample_rate)
 
@@ -142,7 +149,7 @@ class SyncDetector(object):
         return self._orig_infos[fn]
 
     def _align(self, sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
-               max_misalignment, known_delay_ge_map):
+               max_misalignment, known_delay_map):
         """
         Find time delays between video files
         """
@@ -163,7 +170,6 @@ class SyncDetector(object):
 
             exaud_args = dict(
                 sample_rate=sample_rate, video_file=files[idx],
-                starttime_offset=known_delay_ge_map.get(idx, 0),
                 duration=maxmisal)
             # First, try getting from cache.
             ck = None
@@ -180,7 +186,7 @@ class SyncDetector(object):
                 ck = _cache.make_cache_key(**for_cache)
                 cv = _cache.get("_align", ck)
                 if cv:
-                    return cv
+                    return cv[1]
             else:
                 _cache.clean("_align")
 
@@ -194,32 +200,51 @@ class SyncDetector(object):
             del raw_audio
             if not self._dont_cache:
                 _cache.set("_align", ck, (rate, ft_dict))
-            return rate, ft_dict
+            return ft_dict
         #
-        tmp_result = [0.0]
-
-        # Process first file
-        rate, ft_dict1 = _each(0)
+        samps_per_sec = self._sample_rate / float(fft_bin_size)
+        ftds = {i: _each(i) for i in range(len(files))}
+        _result1, _result2 = {}, {}
+        for kdm_key in known_delay_map.keys():
+            kdm = known_delay_map[kdm_key]
+            try:
+                it = files.index(os.path.abspath(kdm_key))
+                ib = files.index(os.path.abspath(kdm["base"]))
+            except ValueError:  # simply ignore
+                continue
+            delay = _find_delay(
+                ftds[ib], ftds[it],
+                kdm.get("min", float("nan")) * samps_per_sec,
+                kdm.get("max", float("nan")) * samps_per_sec)
+            if ib < it:
+                _result1[(ib, it)] = -delay / samps_per_sec
+            else:
+                _result1[(it, ib)] = delay / samps_per_sec
+        #
+        _result2[(0, 0)] = 0.0
         for i in range(len(files) - 1):
-            # Process second file
-            rate, ft_dict2 = _each(i + 1)
-
-            # Determie time delay
-            delay = _find_delay(ft_dict1, ft_dict2)
-            samples_per_sec = float(rate) / float(fft_bin_size)
-            seconds = float(delay) / float(samples_per_sec)
-
-            #
-            tmp_result.append(-seconds)
-
-        result = np.array(tmp_result)
-        if known_delay_ge_map:
-            for i in range(len(result)):
-                if i in known_delay_ge_map:
-                    result += known_delay_ge_map[i]
-                    result[i] -= known_delay_ge_map[i]
+            if (0, i + 1) in _result1:
+                _result2[(0, i + 1)] = _result1[(0, i + 1)]
+            elif (i + 1, 0) in _result1:
+                _result2[(0, i + 1)] = -_result1[(i + 1, 0)]
+            else:
+                delay = _find_delay(ftds[0], ftds[i + 1])
+                _result2[(0, i + 1)] = -delay / samps_per_sec
+        #        [0, 1], [0, 2], [0, 3]
+        # known: [1, 2]
+        # _______________^^^^^^[0, 2] must be calculated by [0, 1], and [1, 2]
+        # 
+        # known: [1, 2], [2, 3]
+        # _______________^^^^^^[0, 2] must be calculated by [0, 1], and [1, 2]
+        # _______________^^^^^^^^[0, 3] must be calculated by [0, 2], and [2, 3]
+        for ib, it in sorted(_result1.keys()):
+            if ib > 0:
+                for i in range(len(files) - 1):
+                    if it == i + 1:
+                        _result2[(0, i + 1)] = _result2[(0, ib)] + _result1[(ib, it)]
 
         # build result
+        result = np.array([_result2[k] for k in sorted(_result2.keys())])
         pad_pre = result - result.min()
         trim_pre = -(pad_pre - pad_pre.max())
         #
@@ -240,13 +265,13 @@ class SyncDetector(object):
         return [self._get_media_info(fn) for fn in files]
 
     def align(self, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, samples_per_box=7,
-              max_misalignment=0, known_delay_ge_map={}):
+              max_misalignment=0, known_delay_map={}):
         """
         Find time delays between video files
         """
         pad_pre, trim_pre = self._align(
             self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
-            max_misalignment, known_delay_ge_map)
+            max_misalignment, known_delay_map)
         #
         infos = self.get_media_info(files)
         orig_dur = np.array([inf["duration"] for inf in infos])
@@ -322,21 +347,29 @@ def main(args=sys.argv):
     parser.add_argument(
         '--max_misalignment',
         type=str, default="1800",
-        help='When handling media files with long playback time, \
-it may take a huge amount of time and huge memory. \
-In such a case, by changing this value to a small value, \
-it is possible to indicate the scanning range of the media file to the program. \
-(default: %(default)s)')
+        help="""When handling media files with long playback time,
+it may take a huge amount of time and huge memory.
+In such a case, by changing this value to a small value,
+it is possible to indicate the scanning range of the media file to the program.
+(default: %(default)s)""")
     parser.add_argument(
-        '--known_delay_ge_map',
+        '--known_delay_map',
         type=str,
-        help='''When handling media files with long playback time, \
-furthermore, when the delay time of a certain movie is large,
-it may take a huge amount of time and huge memory. \
-In such a case, you can give a mapping of the delay times that are roughly known. \
-Please pass it in JSON format, like '{"1": 120}'. The key is an index corresponding \
-to the file passed as "file_names". The value is the number of seconds, meaning \
-"at least larger than this".''')
+        default="{}",
+        help='''\
+Delay detection by feature comparison of frequency intensity may be wrong.
+Since it is an approach that takes only one maximum value of the delay 
+which can best explain the difference in the intensity distribution, if 
+it happens to have a range where characteristics are similar, it adopts it 
+by mistake. "known_delay_map" is a mechanism for forcing this detection
+error manually. For example, if the detection process returns 3 seconds
+despite knowing that the delay is greater than at least 20 minutes,
+you can complain with using "known_delay_map" like "It's over 20 minutes!".
+Please pass it in JSON format, like 
+'{"foo.mp4": {"min": 120, "max": 140, "base": "bar.mp4"}}'
+Specify the adjustment as to which media is adjusted to "base", the minimum and 
+maximum delay as "min", "max". The values of "min", "max"
+are the number of seconds.''')
     parser.add_argument(
         '--sample_rate',
         type=int,
@@ -364,13 +397,7 @@ If you hate this behaviour, specify this option.''' % (
         help='Media files including audio streams. \
 It is possible to pass any media that ffmpeg can handle.',)
     args = parser.parse_args(args[1:])
-    known_delay_ge_map = {}
-    if args.known_delay_ge_map:
-        known_delay_ge_map = json.loads(args.known_delay_ge_map)
-        known_delay_ge_map = {
-            int(k): known_delay_ge_map[k]
-            for k in known_delay_ge_map.keys()
-            }
+    known_delay_map = json.loads(args.known_delay_map)
 
     logging.basicConfig(
         level=logging.DEBUG,
@@ -388,7 +415,7 @@ It is possible to pass any media that ffmpeg can handle.',)
         result = det.align(
             file_specs,
             max_misalignment=communicate.parse_time(args.max_misalignment),
-            known_delay_ge_map=known_delay_ge_map)
+            known_delay_map=known_delay_map)
     if args.json:
         print(json.dumps(
                 {'edit_list': list(zip(file_specs, result))}, indent=4, sort_keys=True))

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -35,7 +35,7 @@ def _build(args):
     base = check_and_decode_filenames(
         [args.base], exit_if_error=True)[0]
     targets = check_and_decode_filenames(
-        args.splitted, min_num_files=2, exit_if_error=True)
+        args.splitted, min_num_files=1, exit_if_error=True)
 
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
@@ -163,11 +163,13 @@ If the key is blank, it means all input streams. Only single input / single outp
 filters can be used.""")
     #####
     parser.add_argument(
-        '--start_gap', choices=['omit', 'pad'], default='omit',
+        '--start_gap', choices=['omit', 'pad'],
         help="""\
 Controling whether to align the start position with `base` or not. \
 The default is "do not align" (`omit`) because it is not normally suitable for the \
-purpose of `concatanate`.""")
+purpose of `concatanate`. The default is "omit" if there are two or more media \
+specified as "splitted". If there is only one media specified as "splitted", \
+the default is "pad", assuming your goal is to fill in the leading gap.""")
     #####
     parser.add_argument(
         '--v_extra_ffargs', type=str,
@@ -190,6 +192,8 @@ If you hate this behaviour, specify this option.''' % (
             _cache.cache_root_dir))
     #####
     args = parser.parse_args(args[1:])
+    if not args.start_gap:
+        args.start_gap = "omit" if len(args.splitted) > 1 else "pad"
     logging.basicConfig(
         level=logging.DEBUG,
         stream=sys.stderr,

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -12,6 +12,7 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 import sys
+import os
 import logging
 import json
 from itertools import chain
@@ -19,7 +20,9 @@ from itertools import chain
 import numpy as np
 
 from .align import SyncDetector
-from .communicate import call_ffmpeg_with_filtercomplex
+from .communicate import (
+    parse_time,
+    call_ffmpeg_with_filtercomplex)
 from .ffmpeg_filter_graph import (
     Filter,
     ConcatWithGapFilterGraphBuilder,
@@ -36,6 +39,12 @@ def _build(args):
         [args.base], exit_if_error=True)[0]
     targets = check_and_decode_filenames(
         args.splitted, min_num_files=1, exit_if_error=True)
+    known_delay_map_orig = json.loads(args.known_delay_map)
+    known_delay_map = {}
+    for k in known_delay_map_orig.keys():
+        nk = os.path.abspath(k)
+        known_delay_map[nk] = known_delay_map_orig[k]
+        known_delay_map[nk]["base"] = os.path.abspath(known_delay_map_orig[k]["base"])
 
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
@@ -48,14 +57,21 @@ def _build(args):
     einf = []
     with SyncDetector(dont_cache=args.dont_cache) as sd:
         start = 0
-        known_delay_ge_map = {}
+        upd = base not in known_delay_map
         for i in range(len(targets)):
+            if upd and start:
+                known_delay_map.update({
+                        base: {
+                            "base": targets[i],
+                            "min": start
+                            }
+                        })
             res = sd.align(
                 [base, targets[i]],
-                known_delay_ge_map=known_delay_ge_map)
+                max_misalignment=parse_time(args.max_misalignment),
+                known_delay_map=known_delay_map)
             gaps.append((start, res[0]["trim"] - start))
             start = res[0]["trim"] + (res[1]["orig_duration"] - res[1]["trim"])
-            known_delay_ge_map[0] = start
             if i == 0:
                 einf.append(res[0])
             einf.append(res[1])
@@ -183,6 +199,18 @@ Additional arguments to ffmpeg for output video streams. Pass list in JSON forma
         help="""\
 Additional arguments to ffmpeg for output audio streams. Pass list in JSON format. \
 (default: '%(default)s')""")
+    #####
+    parser.add_argument(
+        '--max_misalignment',
+        type=str, default="1800",
+        help="""\
+Please see `alignment_info_by_sound_track --help'. (default: %(default)s)'""")
+    parser.add_argument(
+        '--known_delay_map',
+        type=str,
+        default="{}",
+        help="""\
+Please see `alignment_info_by_sound_track --help'.""")
     #####
     parser.add_argument(
         '--dont_cache',

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -570,6 +570,55 @@ def build(definition):
         return files, ";\n".join(result_fg), [], [fconcat.oa[0]]
 
 
+def _make_default_definition_main(args, parser):
+    yn = input("""\
+An editing information file was not specified on the command line.
+Do you scan the current directory and create an information file? [y/n] """)
+    if yn.lower() == "n":
+        if input("""Output help? [y/n] """) == "y":
+            import pydoc
+            pydoc.pager(parser.format_help())
+        return
+    #
+    from glob import glob
+    pat = input("""file's name pattern? [default: '*.mp4'] """)
+    pat = pat if pat else "*.mp4"
+    files = list(glob(pat))
+    with SyncDetector() as sd:
+        infos = list(zip(files, sd.get_media_info(files)))
+    infos.sort(key=lambda x: -x[1]["duration"])
+    result = {
+        "inputs": {
+            "main": {
+                "file": infos[0][0],
+                },
+            "sub": [{"file": inf[0],}
+                    for inf in infos]
+            },
+        "intercuts": [],
+        }
+    if input("""Should I fill in the default "intercuts"? [y/n] """) == "y":
+        idx = 0
+        dur = int(infos[0][1]["duration"])
+        for t in range(0, dur, min(dur // 2, 10)):
+            result["intercuts"].append({
+                    "sub_idx": idx % len(result["inputs"]["sub"]),
+                    "start_time": t,
+                    "time_origin": "main",
+                    "video_mode": "select",
+                    "video_mode_params": ["sub"],
+                    "audio_mode": "select",
+                    "audio_mode_params": ["sub"],
+                    })
+            idx += 1
+
+    ofn = input("""\
+What sort of name will you save this definition? [default: sample.json] """)
+    ofn = ofn if ofn else "sample.json"
+    with io.open(ofn, "w", encoding="utf-8") as fo:
+        json.dump(result, fo, indent=2, sort_keys=True)
+
+
 def main(args=sys.argv):
     import argparse, textwrap
 
@@ -619,6 +668,7 @@ this is not impossible at all, but I would like to avoid confusing users
 who are only interested in the most basic use cases.
 """ % _sample_editinfo), formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("definition",
+                        nargs="?",
                         help="\
 Text (JSON) file describing the definition for indicating the intercuts \
 position.")
@@ -648,6 +698,10 @@ Additional arguments to ffmpeg for output audio streams. Pass list in JSON forma
         level=logging.DEBUG,
         stream=sys.stderr,
         format="%(created)f|%(levelname)5s:%(module)s#%(funcName)s:%(message)s")
+
+    if not args.definition:
+        _make_default_definition_main(args, parser)
+        sys.exit(0)
 
     files, fc, vmap, amap = build(json_load(args.definition))
     v_extra_ffargs = json_loads(args.v_extra_ffargs) if vmap else []

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -325,6 +325,11 @@ def _make_list_of_trims(definition):
     base_trims_table = _mk_trims_table(intercuts, einf, qual)
     last = 0  # default bottom layer for blend
     for i, ins in enumerate(intercuts):
+        if base_trims_table[0][i][0] >= base_trims_table[0][i][1]:
+            # Start >= end, that is, it was completely filled in
+            # the following segment.
+            continue
+
         trims_list.append({
                 k: ins[k] for k in (
                     "video_mode", "video_mode_params",

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -221,7 +221,7 @@ def validate_definition(definition):
             sys.exit(1)
 
 
-def _make_list_of_trims(definition):
+def _make_list_of_trims(definition, max_misalignment, known_delay_map):
     #
     def _translate_definition(definition):
         _inputs = definition["inputs"]  # as human readable
@@ -305,7 +305,10 @@ def _make_list_of_trims(definition):
     files = check_and_decode_filenames(
         [inp["file"] for inp in inputs], exit_if_error=True)
     with SyncDetector() as sd:
-        einf = sd.align(files)
+        einf = sd.align(
+            files,
+            max_misalignment=parse_time(max_misalignment),
+            known_delay_map=known_delay_map)
 
     #
     qual = SyncDetector.summarize_stream_infos(einf)
@@ -451,10 +454,11 @@ Negative time was found ("%s", "%s") for '%s'. """,
     return files, inputs, trims_list, qual
 
 
-def build(definition):
+def build(definition, max_misalignment, known_delay_map):
+    known_delay_map = json.loads(known_delay_map)
     validate_definition(definition)
     files, inputs, trims_list, qual = _make_list_of_trims(
-        definition)
+        definition, max_misalignment, known_delay_map)
 
     # make filter templates
     ftmpl = []
@@ -693,6 +697,18 @@ Additional arguments to ffmpeg for output video streams. Pass list in JSON forma
 Additional arguments to ffmpeg for output audio streams. Pass list in JSON format. \
 (default: '%(default)s')""")
     #####
+    parser.add_argument(
+        '--max_misalignment',
+        type=str, default="1800",
+        help="""\
+Please see `alignment_info_by_sound_track --help'. (default: %(default)s)'""")
+    parser.add_argument(
+        '--known_delay_map',
+        type=str,
+        default="{}",
+        help="""\
+Please see `alignment_info_by_sound_track --help'.""")
+    #####
     args = parser.parse_args(args[1:])
     logging.basicConfig(
         level=logging.DEBUG,
@@ -703,7 +719,10 @@ Additional arguments to ffmpeg for output audio streams. Pass list in JSON forma
         _make_default_definition_main(args, parser)
         sys.exit(0)
 
-    files, fc, vmap, amap = build(json_load(args.definition))
+    files, fc, vmap, amap = build(
+        json_load(args.definition),
+        args.max_misalignment,
+        args.known_delay_map)
     v_extra_ffargs = json_loads(args.v_extra_ffargs) if vmap else []
     a_extra_ffargs = json_loads(args.a_extra_ffargs) if amap else []
     call_ffmpeg_with_filtercomplex(

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -136,7 +136,10 @@ def _build(args):
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
     #
     with SyncDetector(dont_cache=args.dont_cache) as det:
-        ares = det.align(files, max_misalignment=parse_time(args.max_misalignment))
+        ares = det.align(
+            files,
+            max_misalignment=parse_time(args.max_misalignment),
+            known_delay_map=json.loads(args.known_delay_map))
     qual = SyncDetector.summarize_stream_infos(ares)
 
     b = _StackVideosFilterGraphBuilder(
@@ -239,9 +242,16 @@ If the key is blank, it means all input streams. Only single input / single outp
 filters can be used.""")
     #####
     parser.add_argument(
-        '--max_misalignment', type=str, default="600",
+        '--max_misalignment',
+        type=str, default="1800",
         help="""\
-See the help of alignment_info_by_sound_track. (default: %(default)s)""")
+Please see `alignment_info_by_sound_track --help'. (default: %(default)s)'""")
+    parser.add_argument(
+        '--known_delay_map',
+        type=str,
+        default="{}",
+        help="""\
+Please see `alignment_info_by_sound_track --help'.""")
     parser.add_argument(
         '--shape', type=str, default="[2, 2]",
         help="The shape of the tile, like '[2, 2]'. (default: %(default)s)")


### PR DESCRIPTION
Remodeling and modification for each entry point script is trivial. Please see the commit log for these.

The main theme of this time is to stop partial reconstruction of PR#14 and fundamentally change the idea of "known_delay_ge_map". Both motivations are detailed in the commit log, so please refer to that.

I came across a movie where the script certainly mistakenly detects delay detection. "known_delay_map" is for the user to correct this problem manually. Although it is unknown (at least with the eyes and ears of a human being) the special nature of the movie causing the problem, it is a movie that shot the day where the wind is relatively strong outdoors, so it may be deceived by noise caused by this . If the cause is that, I think it might be a good idea to consider some preprocessing (low cut, high cut, band pass etc). I have started trying a little but I have not found a sure way.