### PR TITLE
Make all parameters used for summarizing audio tracks user controllable (and more)

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -88,6 +88,12 @@ class SyncDetectorSummarizerParams(object):
         FFT. That is, it depends on fft_bin_size - overlap. For
         frequencies not to separate, ie, not to create a small box,
         box_height should give (fft_bin_size - overlap) / 2.
+
+    * afilter:
+        This program begins by first extracting audio tracks from the
+        media with ffmpeg. In this case, it is an audio filter given to
+        ffmpeg. If the media is noisy, for example, it may be good to
+        give a bandpass filter etc.
     """
     def __init__(self, **kwargs):
         self.sample_rate = kwargs.get("sample_rate", 48000)

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -136,7 +136,7 @@ class SyncDetector(object):
             self._orig_infos[fn] = communicate.get_media_info(fn)
         return self._orig_infos[fn]
 
-    def _align(self, sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
+    def _align(self, sample_rate, files, fft_bin_size, overlap, box_height, box_width, maxes_per_box,
                max_misalignment, known_delay_map, afilter):
         """
         Find time delays between video files
@@ -169,7 +169,7 @@ class SyncDetector(object):
                         overlap=overlap,
                         box_height=box_height,
                         box_width=box_width,
-                        samples_per_box=samples_per_box,
+                        maxes_per_box=maxes_per_box,
                         atime=os.path.getatime(files[idx])
                         ))
                 ck = _cache.make_cache_key(**for_cache)
@@ -185,7 +185,7 @@ class SyncDetector(object):
             ft_dict = _mk_freq_trans_summary(
                 raw_audio,
                 fft_bin_size, overlap,
-                box_height, box_width, samples_per_box)  # bins, overlap, box height, box width
+                box_height, box_width, maxes_per_box)  # bins, overlap, box height, box width
             del raw_audio
             if not self._dont_cache:
                 _cache.set("_align", ck, (rate, ft_dict))
@@ -251,13 +251,13 @@ class SyncDetector(object):
         """
         return [self._get_media_info(fn) for fn in files]
 
-    def align(self, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, samples_per_box=7,
+    def align(self, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, maxes_per_box=7,
               max_misalignment=0, known_delay_map={}, afilter=""):
         """
         Find time delays between video files
         """
         pad_pre, trim_pre = self._align(
-            self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
+            self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, maxes_per_box,
             max_misalignment, known_delay_map, afilter)
         #
         infos = self.get_media_info(files)

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -131,7 +131,7 @@ class SyncDetector(object):
                 retry -= 1
                 time.sleep(1)
 
-    def _extract_audio(self, sample_rate, video_file, duration):
+    def _extract_audio(self, sample_rate, video_file, duration, afilter):
         """
         Extract audio from video file, save as wav auido file
 
@@ -141,7 +141,8 @@ class SyncDetector(object):
         return communicate.media_to_mono_wave(
             video_file, self._working_dir,
             duration=duration,
-            sample_rate=sample_rate)
+            sample_rate=sample_rate,
+            afilter=afilter)
 
     def _get_media_info(self, fn):
         if fn not in self._orig_infos:
@@ -149,7 +150,7 @@ class SyncDetector(object):
         return self._orig_infos[fn]
 
     def _align(self, sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
-               max_misalignment, known_delay_map):
+               max_misalignment, known_delay_map, afilter):
         """
         Find time delays between video files
         """
@@ -170,7 +171,8 @@ class SyncDetector(object):
 
             exaud_args = dict(
                 sample_rate=sample_rate, video_file=files[idx],
-                duration=maxmisal)
+                duration=maxmisal,
+                afilter=afilter)
             # First, try getting from cache.
             ck = None
             if not self._dont_cache:
@@ -263,13 +265,13 @@ class SyncDetector(object):
         return [self._get_media_info(fn) for fn in files]
 
     def align(self, files, fft_bin_size=1024, overlap=0, box_height=512, box_width=43, samples_per_box=7,
-              max_misalignment=0, known_delay_map={}):
+              max_misalignment=0, known_delay_map={}, afilter=""):
         """
         Find time delays between video files
         """
         pad_pre, trim_pre = self._align(
             self._sample_rate, files, fft_bin_size, overlap, box_height, box_width, samples_per_box,
-            max_misalignment, known_delay_map)
+            max_misalignment, known_delay_map, afilter)
         #
         infos = self.get_media_info(files)
         orig_dur = np.array([inf["duration"] for inf in infos])

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -12,24 +12,11 @@ the python libraries scipy and numpy.
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
-_doc_template = '''
-    %(prog)s <file1> <file2>
-
-This program reports the offset difference for audio and video files,
-containing audio recordings from the same event. It relies on ffmpeg being
-installed and the python libraries scipy and numpy.
-
-It reports back the offset. Example:
-
-    %(prog)s good_video_shitty_audio.mp4 good_audio_shitty_video.mp4
-
-    Result: The beginning of good_video_shitty_audio.mp4 needs to be trimmed off 11.348 seconds for all files to be in sync
-
-'''
 import os
 import sys
 from collections import defaultdict
 import math
+import json
 import tempfile
 import shutil
 import logging
@@ -335,15 +322,17 @@ class SyncDetector(object):
 
 
 def _bailout(parser):
-    parser.print_usage()
+    parser.print_help()
     sys.exit(1)
 
 
 def main(args=sys.argv):
     import argparse
-    import json
 
-    parser = argparse.ArgumentParser(prog=args[0], usage=_doc_template)
+    parser = argparse.ArgumentParser(description="""\
+This program reports the offset difference for audio and video files,
+containing audio recordings from the same event. It relies on ffmpeg being
+installed and the python libraries scipy and numpy.""")
     parser.add_argument(
         '--max_misalignment',
         type=str, default="1800",

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -381,6 +381,7 @@ def media_to_mono_wave(
     starttime_offset=0,  # -ss
     duration=0,  # -t
     sample_rate=48000,  # -ar
+    afilter="",  # -af
     ):
     """
     Convert the given media to monoral WAV by calling `ffmpeg`.
@@ -390,13 +391,16 @@ def media_to_mono_wave(
     # existence in getatime to understand easily.
     os.path.getatime(video_file)
 
-    _ffmpeg_ss_args = (None, None)
-    ffmpeg_t_args = (None, None)
+    _ss_args = (None, None)
+    _t_args = (None, None)
+    _af_args = (None, None)
     if starttime_offset > 0:
-        _ffmpeg_ss_args = (
+        _ss_args = (
             "-ss", duration_to_hhmmss(starttime_offset))
     if duration and duration > 0:
-        ffmpeg_t_args = ("-t", "%d" % duration)
+        _t_args = ("-t", "%d" % duration)
+    if afilter:
+        _af_args = ("-af", afilter)
 
     track_name = os.path.basename(video_file)
     # !! CHECK TO SEE IF FILE IS IN UPLOADS DIRECTORY
@@ -407,10 +411,11 @@ def media_to_mono_wave(
     if not os.path.exists(output):
         cmd = [
                 "ffmpeg", "-hide_banner", "-y",
-                _ffmpeg_ss_args[0], _ffmpeg_ss_args[1],
-                ffmpeg_t_args[0], ffmpeg_t_args[1],
+                _ss_args[0], _ss_args[1],
+                _t_args[0], _t_args[1],
                 "-i", "%s" % video_file,
                 "-vn",
+                _af_args[0], _af_args[1],
                 "-ar", "%d" % sample_rate,
                 "-ac", "1",
                 "-f", "wav",

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -25,7 +25,7 @@ import logging
 
 import numpy as np
 
-from .align import SyncDetector
+from .align import SyncDetector, SyncDetectorSummarizerParams
 from .communicate import (
     parse_time,
     call_ffmpeg_with_filtercomplex,
@@ -304,11 +304,11 @@ def _make_list_of_trims(definition, max_misalignment, known_delay_map):
     inputs, intercuts = _translate_definition(definition)
     files = check_and_decode_filenames(
         [inp["file"] for inp in inputs], exit_if_error=True)
-    with SyncDetector() as sd:
+    params = SyncDetectorSummarizerParams(
+        max_misalignment=parse_time(max_misalignment))
+    with SyncDetector(params=params) as sd:
         einf = sd.align(
-            files,
-            max_misalignment=parse_time(max_misalignment),
-            known_delay_map=known_delay_map)
+            files, known_delay_map=known_delay_map)
 
     #
     qual = SyncDetector.summarize_stream_infos(einf)

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -591,8 +591,11 @@ Do you scan the current directory and create an information file? [y/n] """)
         if not os.path.exists(main_media):
             main_media = None
 
-    pat = input("""name pattern for sub materials? [default: '*.mp4'] """)
-    pat = pat if pat else "*.mp4"
+    while True:
+        pat = input("""name pattern for sub materials? [default: '*.mp4'] """)
+        pat = pat if pat else "*.mp4"
+        if list(glob(pat)):
+            break
     files = [main_media] + list(glob(pat))
     with SyncDetector() as sd:
         infos = list(zip(files, sd.get_media_info(files)))
@@ -603,7 +606,7 @@ Do you scan the current directory and create an information file? [y/n] """)
                 "file": infos[0][0],
                 },
             "sub": [{"file": inf[0],}
-                    for inf in infos]
+                    for inf in infos[1:]]
             },
         "intercuts": [],
         }

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -585,9 +585,15 @@ Do you scan the current directory and create an information file? [y/n] """)
         return
     #
     from glob import glob
-    pat = input("""file's name pattern? [default: '*.mp4'] """)
+    main_media = None
+    while not main_media:
+        main_media = input("""main media? """)
+        if not os.path.exists(main_media):
+            main_media = None
+
+    pat = input("""name pattern for sub materials? [default: '*.mp4'] """)
     pat = pat if pat else "*.mp4"
-    files = list(glob(pat))
+    files = [main_media] + list(glob(pat))
     with SyncDetector() as sd:
         infos = list(zip(files, sd.get_media_info(files)))
     infos.sort(key=lambda x: -x[1]["duration"])

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -304,11 +304,12 @@ def _make_list_of_trims(definition, max_misalignment, known_delay_map):
     inputs, intercuts = _translate_definition(definition)
     files = check_and_decode_filenames(
         [inp["file"] for inp in inputs], exit_if_error=True)
-    params = SyncDetectorSummarizerParams(
-        max_misalignment=parse_time(max_misalignment))
+    if args.summarizer_params:
+        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
+    else:
+        params = SyncDetectorSummarizerParams()
     with SyncDetector(params=params) as sd:
-        einf = sd.align(
-            files, known_delay_map=known_delay_map)
+        einf = sd.align(files, known_delay_map=known_delay_map)
 
     #
     qual = SyncDetector.summarize_stream_infos(einf)
@@ -707,10 +708,9 @@ Additional arguments to ffmpeg for output audio streams. Pass list in JSON forma
 (default: '%(default)s')""")
     #####
     parser.add_argument(
-        '--max_misalignment',
-        type=str, default="1800",
-        help="""\
-Please see `alignment_info_by_sound_track --help'. (default: %(default)s)'""")
+        '--summarizer_params',
+        type=str,
+        help="""Please see `alignment_info_by_sound_track --help'.""")
     parser.add_argument(
         '--known_delay_map',
         type=str,

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -20,7 +20,7 @@ from itertools import chain
 
 import numpy as np
 
-from .align import SyncDetector
+from .align import SyncDetector, SyncDetectorSummarizerParams
 from .communicate import parse_time, call_ffmpeg_with_filtercomplex
 from .ffmpeg_filter_graph import Filter, ConcatWithGapFilterGraphBuilder
 from .utils import check_and_decode_filenames
@@ -135,10 +135,11 @@ def _build(args):
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
     #
-    with SyncDetector(dont_cache=args.dont_cache) as det:
+    params = SyncDetectorSummarizerParams(
+        max_misalignment=parse_time(args.max_misalignment))
+    with SyncDetector(params=params, dont_cache=args.dont_cache) as det:
         ares = det.align(
             files,
-            max_misalignment=parse_time(args.max_misalignment),
             known_delay_map=json.loads(args.known_delay_map))
     qual = SyncDetector.summarize_stream_infos(ares)
 
@@ -148,27 +149,27 @@ def _build(args):
         h=args.h,
         fps=qual["max_fps"],
         sample_rate=args.sample_rate if args.sample_rate else qual["max_sample_rate"])
-    with SyncDetector(dont_cache=args.dont_cache) as det:
-        for i, inf in enumerate(ares):
-            pre, post = inf["pad"], inf["pad_post"]
-            if not (pre > 0 and post > 0):
-                # FIXME:
-                #  In this case, if we don't add paddings, we'll encount the following:
-                #    [AVFilterGraph @ 0000000003146500] The following filters could not
-                #choose their formats: Parsed_amerge_48
-                #    Consider inserting the (a)format filter near their input or output.
-                #    Error reinitializing filters!
-                #    Failed to inject frame into filter network: I/O error
-                #    Error while processing the decoded data for stream #3:0
-                #    Conversion failed!
-                #
-                #  Just by adding padding just like any other stream, it seems we can
-                #  avoid it, so let's add meaningless padding as a workaround.
-                post = post + 1.0
 
-            vf = ",".join(filter(None, [v_filter_extra.get(""), v_filter_extra.get("%d" % i)]))
-            af = ",".join(filter(None, [a_filter_extra.get(""), a_filter_extra.get("%d" % i)]))
-            b.set_paddings(i, pre, post, vf, af)
+    for i, inf in enumerate(ares):
+        pre, post = inf["pad"], inf["pad_post"]
+        if not (pre > 0 and post > 0):
+            # FIXME:
+            #  In this case, if we don't add paddings, we'll encount the following:
+            #    [AVFilterGraph @ 0000000003146500] The following filters could not
+            #choose their formats: Parsed_amerge_48
+            #    Consider inserting the (a)format filter near their input or output.
+            #    Error reinitializing filters!
+            #    Failed to inject frame into filter network: I/O error
+            #    Error while processing the decoded data for stream #3:0
+            #    Conversion failed!
+            #
+            #  Just by adding padding just like any other stream, it seems we can
+            #  avoid it, so let's add meaningless padding as a workaround.
+            post = post + 1.0
+
+        vf = ",".join(filter(None, [v_filter_extra.get(""), v_filter_extra.get("%d" % i)]))
+        af = ",".join(filter(None, [a_filter_extra.get(""), a_filter_extra.get("%d" % i)]))
+        b.set_paddings(i, pre, post, vf, af)
 
     #
     filters = []

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -135,8 +135,10 @@ def _build(args):
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
     #
-    params = SyncDetectorSummarizerParams(
-        max_misalignment=parse_time(args.max_misalignment))
+    if args.summarizer_params:
+        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
+    else:
+        params = SyncDetectorSummarizerParams()
     with SyncDetector(params=params, dont_cache=args.dont_cache) as det:
         ares = det.align(
             files,
@@ -243,10 +245,9 @@ If the key is blank, it means all input streams. Only single input / single outp
 filters can be used.""")
     #####
     parser.add_argument(
-        '--max_misalignment',
-        type=str, default="1800",
-        help="""\
-Please see `alignment_info_by_sound_track --help'. (default: %(default)s)'""")
+        '--summarizer_params',
+        type=str,
+        help="""Please see `alignment_info_by_sound_track --help'.""")
     parser.add_argument(
         '--known_delay_map',
         type=str,

--- a/align_videos_by_soundtrack/trim.py
+++ b/align_videos_by_soundtrack/trim.py
@@ -12,7 +12,7 @@ import sys
 import json
 import logging
 
-from .align import SyncDetector
+from .align import SyncDetector, SyncDetectorSummarizerParams
 from .communicate import (
     parse_time,
     check_call,
@@ -58,10 +58,11 @@ Please see `alignment_info_by_sound_track --help'.""")
     import os
     if not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
+    params = SyncDetectorSummarizerParams(
+        max_misalignment=parse_time(args.max_misalignment))
     with SyncDetector() as sd:
         infos = sd.align(
             files,
-            max_misalignment=parse_time(args.max_misalignment),
             known_delay_map=json.loads(args.known_delay_map))
 
         for fn, editinfo in list(zip(files, infos)):

--- a/align_videos_by_soundtrack/trim.py
+++ b/align_videos_by_soundtrack/trim.py
@@ -36,10 +36,9 @@ def main(args=sys.argv):
         "--trim_end", action="store_true")
     #####
     parser.add_argument(
-        '--max_misalignment',
-        type=str, default="1800",
-        help="""\
-Please see `alignment_info_by_sound_track --help'. (default: %(default)s)'""")
+        '--summarizer_params',
+        type=str,
+        help="""Please see `alignment_info_by_sound_track --help'.""")
     parser.add_argument(
         '--known_delay_map',
         type=str,
@@ -58,9 +57,11 @@ Please see `alignment_info_by_sound_track --help'.""")
     import os
     if not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
-    params = SyncDetectorSummarizerParams(
-        max_misalignment=parse_time(args.max_misalignment))
-    with SyncDetector() as sd:
+    if args.summarizer_params:
+        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
+    else:
+        params = SyncDetectorSummarizerParams()
+    with SyncDetector(params=params) as sd:
         infos = sd.align(
             files,
             known_delay_map=json.loads(args.known_delay_map))

--- a/align_videos_by_soundtrack/utils.py
+++ b/align_videos_by_soundtrack/utils.py
@@ -85,7 +85,7 @@ def json_load(jsonfilename):
 # Validation helpers
 #
 def validate_type_one_by_template(
-    chktrg, tmpl, depthstr, not_empty=True, exit_on_error=True):
+    chktrg, tmpl, depthstr="", not_empty=True, exit_on_error=True):
 
     if type(chktrg) != type(tmpl) or not chktrg:
         _logger.error("""%s must be %s""" % (
@@ -97,15 +97,15 @@ def validate_type_one_by_template(
 
 
 def validate_dict_one_by_template(
-    chktrg, tmpl, mandkeys, depthstr, not_empty=True, exit_on_error=True):
+    chktrg, tmpl, mandkeys=[], depthstr="", not_empty=True, exit_on_error=True):
 
     if not validate_type_one_by_template(
         chktrg, tmpl, depthstr, not_empty, exit_on_error):
         return False
-
+    depthstr = "in %s" % depthstr if depthstr else ""
     for mk in mandkeys:
         if mk not in chktrg:
-            _logger.error("""Missing key '%s' in %s""" % (
+            _logger.error("""Missing key '%s' %s""" % (
                     mk, depthstr))
             if exit_on_error:
                 sys.exit(1)
@@ -113,7 +113,7 @@ def validate_dict_one_by_template(
     allow_keys = tmpl.keys()
     unk = (set(allow_keys) | set(chktrg.keys())) - set(allow_keys)
     if unk:
-        _logger.error("""Unknown keys in %s: %s""" % (
+        _logger.error("""Unknown keys %s: %s""" % (
                 depthstr, ", ".join(list(unk))))
         if exit_on_error:
             sys.exit(1)


### PR DESCRIPTION
Regarding the movie where the program incorrectly detects the delay, I still do not know the 
correct answer, in various trial and error, it became clear that it often happens that 
correct answer is returned only by slightly changing parameters currently being handled. 
Although it may become a heavy customization for users who do not know about how it works, 
but, Even if not, I wanted a way to change the parameters without changing the program. As a result, 
it is no longer necessary to change the program for my trial and error.

I changed the interface of the script greatly, but I want you to think that it is simple. (That is, 
all the previous "max_misalignment" etc. were also included in the new summarizer_params.)

In addition, we made it possible to instruct "-af" when extracting audio tracks, and also added
simple lowcut and highcut. At least for me, lowcut seems useful in my case.
