### PR TITLE
I broke simple_compile_videos_by_sound_track...

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -224,6 +224,7 @@ class _FreqTransSummarizer(object):
             afilter=self._params.afilter)
 
     def summarize_audiotrack(self, media, dont_cache):
+        _logger.info("for '%s' begin", os.path.basename(media))
         exaud_args = dict(video_file=media, duration=self._params.max_misalignment)
         # First, try getting from cache.
         ck = None
@@ -236,15 +237,19 @@ class _FreqTransSummarizer(object):
             ck = _cache.make_cache_key(**for_cache)
             cv = _cache.get("_align", ck)
             if cv:
+                _logger.info("for '%s' end", os.path.basename(media))
                 return cv[1]
         else:
             _cache.clean("_align")
 
         # Not found in cache.
+        _logger.info("extracting audio tracks for '%s' begin", os.path.basename(media))
         wavfile = self._extract_audio(**exaud_args)
+        _logger.info("extracting audio tracks for '%s' end", os.path.basename(media))
         rate, ft_dict = self._summarize_wav(wavfile)
         if not dont_cache:
             _cache.set("_align", ck, (rate, ft_dict))
+        _logger.info("for '%s' end", os.path.basename(media))
         return ft_dict
 
     def find_delay(

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -196,7 +196,7 @@ class _FreqTransSummarizer(object):
         return freqs_dict
 
     def _secs_to_x(self, secs):
-        j = secs * float(self._params.sample_rate)
+        j = (secs if secs is not None else 0) * float(self._params.sample_rate)
         x = (j + self._params.overlap) / (self._params.fft_bin_size - self._params.overlap)
         return x
 

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -136,11 +136,13 @@ class SyncDetectorSummarizerParams(object):
 
     @staticmethod
     def from_json(s):
-        d = json_loads(s)
+        if s:
+            d = json_loads(s)
 
-        tmpl = SyncDetectorSummarizerParams()
-        validate_dict_one_by_template(d, tmpl.__dict__)
-        return SyncDetectorSummarizerParams(**d)
+            tmpl = SyncDetectorSummarizerParams()
+            validate_dict_one_by_template(d, tmpl.__dict__)
+            return SyncDetectorSummarizerParams(**d)
+        return SyncDetectorSummarizerParams()
 
 
 class _FreqTransSummarizer(object):
@@ -510,10 +512,7 @@ It is possible to pass any media that ffmpeg can handle.',)
         args.file_names, min_num_files=2)
     if not file_specs:
         _bailout(parser)
-    if args.summarizer_params:
-        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
-    else:
-        params = SyncDetectorSummarizerParams()
+    params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
     with SyncDetector(
         params=params,
         dont_cache=args.dont_cache) as det:

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -55,10 +55,7 @@ def _build(args):
     gaps = []
     #
     einf = []
-    if args.summarizer_params:
-        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
-    else:
-        params = SyncDetectorSummarizerParams()
+    params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
     with SyncDetector(params=params, dont_cache=args.dont_cache) as sd:
         start = 0
         upd = base not in known_delay_map

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -145,7 +145,7 @@ but it goes without saying that it's a "strange" movie.""")
         "-o", "--outfile", dest="outfile", default="concatenated.mp4",
         help="Specifying the output file. (default: %(default)s)")
     parser.add_argument(
-        '--mode', choices=['script_bash', 'direct'], default='script_bash',
+        '--mode', choices=['script_bash', 'script_python', 'direct'], default='script_bash',
         help="""\
 Switching whether to produce bash shellscript or to call ffmpeg directly. (default: %(default)s)""")
     #

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -304,10 +304,7 @@ def _make_list_of_trims(definition, max_misalignment, known_delay_map):
     inputs, intercuts = _translate_definition(definition)
     files = check_and_decode_filenames(
         [inp["file"] for inp in inputs], exit_if_error=True)
-    if args.summarizer_params:
-        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
-    else:
-        params = SyncDetectorSummarizerParams()
+    params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
     with SyncDetector(params=params) as sd:
         einf = sd.align(files, known_delay_map=known_delay_map)
 

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -221,7 +221,7 @@ def validate_definition(definition):
             sys.exit(1)
 
 
-def _make_list_of_trims(definition, max_misalignment, known_delay_map):
+def _make_list_of_trims(definition, known_delay_map, args):
     #
     def _translate_definition(definition):
         _inputs = definition["inputs"]  # as human readable
@@ -452,11 +452,11 @@ Negative time was found ("%s", "%s") for '%s'. """,
     return files, inputs, trims_list, qual
 
 
-def build(definition, max_misalignment, known_delay_map):
+def build(definition, known_delay_map, args):
     known_delay_map = json.loads(known_delay_map)
     validate_definition(definition)
     files, inputs, trims_list, qual = _make_list_of_trims(
-        definition, max_misalignment, known_delay_map)
+        definition, known_delay_map, args)
 
     # make filter templates
     ftmpl = []
@@ -687,7 +687,7 @@ position.")
         "-o", "--outfile", dest="outfile", default="compiled.mp4",
         help="Specifying the output file. (default: %(default)s)")
     parser.add_argument(
-        '--mode', choices=['script_bash', 'direct'], default='script_bash',
+        '--mode', choices=['script_bash', 'script_python', 'direct'], default='script_bash',
         help="""\
 Switching whether to produce bash shellscript or to call ffmpeg directly. (default: %(default)s)""")
     #####
@@ -727,8 +727,7 @@ Please see `alignment_info_by_sound_track --help'.""")
 
     files, fc, vmap, amap = build(
         json_load(args.definition),
-        args.max_misalignment,
-        args.known_delay_map)
+        args.known_delay_map, args)
     v_extra_ffargs = json_loads(args.v_extra_ffargs) if vmap else []
     a_extra_ffargs = json_loads(args.a_extra_ffargs) if amap else []
     call_ffmpeg_with_filtercomplex(

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -135,10 +135,7 @@ def _build(args):
     a_filter_extra = json.loads(args.a_filter_extra) if args.a_filter_extra else {}
     v_filter_extra = json.loads(args.v_filter_extra) if args.v_filter_extra else {}
     #
-    if args.summarizer_params:
-        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
-    else:
-        params = SyncDetectorSummarizerParams()
+    params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
     with SyncDetector(params=params, dont_cache=args.dont_cache) as det:
         ares = det.align(
             files,

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -207,7 +207,7 @@ different thing from this. See the option description.""")
         "-o", "--outfile", dest="outfile", default="merged.mp4",
         help="Specifying the output file. (default: %(default)s)")
     parser.add_argument(
-        '--mode', choices=['script_bash', 'direct'], default='script_bash',
+        '--mode', choices=['script_bash', 'script_python', 'direct'], default='script_bash',
         help="""\
 Switching whether to produce bash shellscript or to call ffmpeg directly. (default: %(default)s)""")
     #####

--- a/align_videos_by_soundtrack/trim.py
+++ b/align_videos_by_soundtrack/trim.py
@@ -57,10 +57,7 @@ Please see `alignment_info_by_sound_track --help'.""")
     import os
     if not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
-    if args.summarizer_params:
-        params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
-    else:
-        params = SyncDetectorSummarizerParams()
+    params = SyncDetectorSummarizerParams.from_json(args.summarizer_params)
     with SyncDetector(params=params) as sd:
         infos = sd.align(
             files,


### PR DESCRIPTION
Sorry...

And, I added a "script_python" mode I was planning to do from a long time ago. This is less necessary for me. However, there is a possibility that the Windows user shouts that "I do not have bash!" At that time, it is most tragic for all users and developers that the user wishes "DOS mode too!". Even batch files of DOS that are not auto-generated are even harder to withstand maintenance. Especially fighting with inexplicable quotation rules will suffer not only users who get this, but also developers that generate auto-generated code. If that can easily be anticipated, what we should do is not to annoy the Windows users (which do not have any UNIX-like environment).

And, I added logging I was planning to do from a long time ago too.  If you handle media such as 20 minutes or 30 minutes, "align" will take minutes to process, so the user will be worried that "When will it end?" "Do it end in the first place?"