### PR TITLE
Bugfixes and updated simple_compile_videos_by_sound_track, concat_videos_by_sound_track

### DIFF
--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -212,14 +212,15 @@ class SyncDetector(object):
         _result1, _result2 = {}, {}
         for kdm_key in known_delay_map.keys():
             kdm = known_delay_map[kdm_key]
-            try:
-                it = files.index(os.path.abspath(kdm_key))
-                ib = files.index(os.path.abspath(kdm["base"]))
-            except ValueError:  # simply ignore
-                continue
-            _result1[(ib, it)] = -self._impl.find_delay(
-                ftds[ib], ftds[it],
-                kdm.get("min", float('nan')), kdm.get("max", float('nan')))
+            ft = os.path.abspath(kdm_key)
+            fb = os.path.abspath(kdm["base"])
+            it_all = [i for i, f in enumerate(files) if f == ft]
+            ib_all = [i for i, f in enumerate(files) if f == fb]
+            for it in it_all:
+                for ib in ib_all:
+                    _result1[(ib, it)] = -self._impl.find_delay(
+                        ftds[ib], ftds[it],
+                        kdm.get("min", float('nan')), kdm.get("max", float('nan')))
         #
         _result2[(0, 0)] = 0.0
         for i in range(len(files) - 1):

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -90,7 +90,7 @@ class _FreqTransSummarizer(object):
         return freqs_dict
 
     def _secs_to_x(self, secs):
-        j = (secs if secs is not None else 0) * float(self._params.sample_rate)
+        j = secs * float(self._params.sample_rate)
         x = (j + self._params.overlap) / (self._params.fft_bin_size - self._params.overlap)
         return x
 
@@ -217,7 +217,8 @@ class SyncDetector(object):
             except ValueError:  # simply ignore
                 continue
             _result1[(ib, it)] = -self._impl.find_delay(
-                ftds[ib], ftds[it], kdm.get("min"), kdm.get("max"))
+                ftds[ib], ftds[it],
+                kdm.get("min", float('nan')), kdm.get("max", float('nan')))
         #
         _result2[(0, 0)] = 0.0
         for i in range(len(files) - 1):

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -162,14 +162,15 @@ class _FreqTransSummarizer(object):
                     delta_t = x_i - x_j
                     mincond_ok = math.isnan(min_delay) or delta_t >= min_delay
                     maxcond_ok = math.isnan(max_delay) or delta_t <= max_delay
-                    inc = 1 if mincond_ok and maxcond_ok else 0
-                    t_diffs[delta_t] += inc
-    
-        t_diffs_sorted = sorted(list(t_diffs.items()), key=lambda x: x[1])
-        # _logger.debug(t_diffs_sorted)
-        time_delay = t_diffs_sorted[-1][0]
-
-        return self._x_to_secs(time_delay)
+                    if mincond_ok and maxcond_ok:
+                        t_diffs[delta_t] += 1
+        try:
+            return self._x_to_secs(
+                sorted(list(t_diffs.items()), key=lambda x: -x[1])[0][0])
+        except IndexError as e:
+            raise Exception(
+                """I could not find a match. \
+Are the target medias sure to shoot the same event?""")
 
 
 class SyncDetector(object):

--- a/align_videos_by_soundtrack/align.py
+++ b/align_videos_by_soundtrack/align.py
@@ -155,6 +155,9 @@ class _FreqTransSummarizer(object):
                 """I could not find a match. Consider giving a large value to \
 "max_misalignment" if the target medias are sure to shoot the same event.""")
         #
+        if freqs_dict_orig == freqs_dict_sample:
+            return 0.0
+        #
         t_diffs = defaultdict(int)
         for key in keys:
             for x_i in freqs_dict_sample[key]:  # determine time offset

--- a/align_videos_by_soundtrack/cli_common.py
+++ b/align_videos_by_soundtrack/cli_common.py
@@ -174,8 +174,7 @@ Additional arguments to ffmpeg for output audio streams. Pass list in JSON forma
             args.summarizer_params)
         #
         if hasattr(args, "outparams"):
-            args.outparams = EditorOutputParams(
-                **(json_loads(args.outparams) if args.outparams else {}))
+            args.outparams = EditorOutputParams.from_json(args.outparams)
         if hasattr(args, "a_filter_extra"):
             args.a_filter_extra = json_loads(args.a_filter_extra) if args.a_filter_extra else {}
         if hasattr(args, "v_filter_extra"):

--- a/align_videos_by_soundtrack/cli_common.py
+++ b/align_videos_by_soundtrack/cli_common.py
@@ -174,7 +174,8 @@ Additional arguments to ffmpeg for output audio streams. Pass list in JSON forma
             args.summarizer_params)
         #
         if hasattr(args, "outparams"):
-            args.outparams = json_loads(args.outparams) if args.outparams else {}
+            args.outparams = EditorOutputParams(
+                **(json_loads(args.outparams) if args.outparams else {}))
         if hasattr(args, "a_filter_extra"):
             args.a_filter_extra = json_loads(args.a_filter_extra) if args.a_filter_extra else {}
         if hasattr(args, "v_filter_extra"):

--- a/align_videos_by_soundtrack/cli_common.py
+++ b/align_videos_by_soundtrack/cli_common.py
@@ -108,14 +108,16 @@ for some reason, specify this.''' % (
             "-o", "--outfile", dest="outfile", default=default,
             help="Specifying the output file. (default: %(default)s)")
 
-    def editor_add_output_params_argument(self):
+    def editor_add_output_params_argument(self, notice=""):
         default = EditorOutputParams()
         default = json.dumps(default.__dict__)
         self.add_argument(
             "--outparams",
             help="""Parameters for output. Pass in JSON format, 
 in dictionary format. For example, '{"fps": 29.97, "sample_rate": 44100}'
-etc. (default: %s).""" % default,
+etc.
+ %s
+ (default: %s).""" % (notice, default),
             default=default)
 
     def editor_add_mode_argument(self):

--- a/align_videos_by_soundtrack/cli_common.py
+++ b/align_videos_by_soundtrack/cli_common.py
@@ -15,6 +15,7 @@ import logging
 import os
 
 from .align_params import SyncDetectorSummarizerParams
+from .edit_outparams import EditorOutputParams
 from . import _cache
 from .utils import json_loads
 
@@ -107,6 +108,16 @@ for some reason, specify this.''' % (
             "-o", "--outfile", dest="outfile", default=default,
             help="Specifying the output file. (default: %(default)s)")
 
+    def editor_add_output_params_argument(self):
+        default = EditorOutputParams()
+        default = json.dumps(default.__dict__)
+        self.add_argument(
+            "--outparams",
+            help="""Parameters for output. Pass in JSON format, 
+in dictionary format. For example, '{"fps": 29.97, "sample_rate": 44100}'
+etc. (default: %s).""" % default,
+            default=default)
+
     def editor_add_mode_argument(self):
         self.add_argument(
             '--mode', choices=['script_bash', 'script_python', 'direct'], default='script_bash',
@@ -162,6 +173,8 @@ Additional arguments to ffmpeg for output audio streams. Pass list in JSON forma
         args.summarizer_params = SyncDetectorSummarizerParams.from_json(
             args.summarizer_params)
         #
+        if hasattr(args, "outparams"):
+            args.outparams = json_loads(args.outparams) if args.outparams else {}
         if hasattr(args, "a_filter_extra"):
             args.a_filter_extra = json_loads(args.a_filter_extra) if args.a_filter_extra else {}
         if hasattr(args, "v_filter_extra"):

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -488,7 +488,7 @@ def call_ffmpeg_with_filtercomplex(
 #! /bin/sh
 # -*- coding: utf-8 -*-
 
-ffmpeg -y \\
+ffmpeg -hide_banner -y \\
   {} \\
   -filter_complex "
 {}
@@ -497,7 +497,7 @@ ffmpeg -y \\
            filter_complex,
            " ".join(_quote.map(map_args))).encode("utf-8"))
     else:
-        cmd = ["ffmpeg", "-y"]
+        cmd = ["ffmpeg", "-hide_banner", "-y"]
         cmd.extend(ifile_args)
         cmd.extend(["-filter_complex", filter_complex])
         cmd.extend(map_args)

--- a/align_videos_by_soundtrack/communicate.py
+++ b/align_videos_by_soundtrack/communicate.py
@@ -436,28 +436,45 @@ def call_ffmpeg_with_filtercomplex(
     mode,
     inputfiles,
     filter_complex,
-    extra_ffargs,
-    maps,  # [("[v0]", "[a0]"), ("[v1]", "[a1]"), ("[v2]", "[a2]"), ...]
+    vmap,  # ["[v0]", "[v1]", ...]
+    amap,  # ["[a0]", "[a1]", ...]
+    v_extra_ffargs,
+    a_extra_ffargs,
     outfiles):
     """
     Call ffmpeg or print a `bash` script.
 
-    Calling ffmpeg is complicated, such as extremely delicate argument order,
-    or there are also too flexible aliases, and enormous variation calling
-    is possible if including up to deprecated options. but if it is called
-    only by `-filter_complex` and` -map`, it is almost the same way of calling it.
+    Calling ffmpeg is complicated, such as extremely delicate argument
+    order, or there are also too flexible aliases, and enormous variation
+    calling is possible if including up to deprecated options. but if it
+    is called only by `-filter_complex` and` -map`, it is almost the same
+    way of calling it.
     """
     ifile_args = chain.from_iterable([('-i', f) for f in inputfiles])
+    #
+    if vmap:
+        maps = zip(vmap, amap)  # [("[v0]", "[a0]"), ("[v1]", "[a1]"), ...]
+    elif amap:
+        maps = [amap]
+    else:
+        raise ValueError("no maps")
+    v_extra_ffargs = v_extra_ffargs if vmap else []
+    a_extra_ffargs = a_extra_ffargs if amap else []
+
+    extra_ffargs = v_extra_ffargs + a_extra_ffargs
+    #
     if len(outfiles) > 1:
         map_args = []
         for zi in zip(maps, outfiles):
-            map_args.extend(chain.from_iterable([("-map", m) for m in zi[0] if m]))
+            map_args.extend(chain.from_iterable(
+                    [("-map", m) for m in zi[0] if m]))
             map_args.extend(extra_ffargs)
             map_args.append(zi[1])
     else:
         map_args = []
         for mi in maps:
-            map_args.extend(chain.from_iterable([("-map", m) for m in mi if m]))
+            map_args.extend(chain.from_iterable(
+                    [("-map", m) for m in mi if m]))
         map_args.extend(extra_ffargs)
         map_args.append(outfiles[0])
     #

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -81,8 +81,8 @@ def _build(args):
     outparams.fix_params(qual)
     bld = ConcatWithGapFilterGraphBuilder(
         "c",
-        w=qual["max_width"],
-        h=qual["max_height"],
+        w=outparams.width,
+        h=outparams.height,
         fps=outparams.fps,
         sample_rate=outparams.sample_rate)
     def _add_gap(start, gap):

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -122,7 +122,11 @@ def _build(args):
     if end_pad and args.end_gap == "pad":
         start, gap = gaps[len(targets)]
         _add_gap(start, gap)
-    fc, vmap, amap = bld.build()
+    try:
+        fc, vmap, amap = bld.build()
+    except Exception as e:
+        _logger.warning("Nothing to do.")
+        sys.exit(0)
     return [base] + targets, fc, [vmap], [amap]
 
 

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -45,11 +45,12 @@ def _build(args):
     gaps = []
     #
     einf = []
+    start = 0
+    base_dur = 0
     with SyncDetector(
         params=args.summarizer_params,
         clear_cache=args.clear_cache) as sd:
 
-        start = 0
         upd = base not in known_delay_map
         for i in range(len(targets)):
             if upd and start:
@@ -62,11 +63,17 @@ def _build(args):
             res = sd.align(
                 [base, targets[i]],
                 known_delay_map=known_delay_map)
+            base_dur = res[0]["orig_duration"]
             gaps.append((start, res[0]["trim"] - start))
-            start = res[0]["trim"] + (res[1]["orig_duration"] - res[1]["trim"])
+            start = res[0]["trim"] + (
+                res[1]["orig_duration"] - res[1]["trim"])
             if i == 0:
                 einf.append(res[0])
             einf.append(res[1])
+    end_pad = False
+    if start < base_dur:
+        end_pad = True
+        gaps.append((start, base_dur - start))
     #
     qual = SyncDetector.summarize_stream_infos(einf)
     targets_have_video = any(qual["has_video"][1:])
@@ -76,8 +83,7 @@ def _build(args):
         h=qual["max_height"],
         fps=qual["max_fps"],
         sample_rate=qual["max_sample_rate"])
-    for i in range(len(targets)):
-        start, gap = gaps[i]
+    def _add_gap(start, gap):
         if gap > 0 and (
             not np.isclose(start, 0) or args.start_gap != "omit"):
 
@@ -86,7 +92,9 @@ def _build(args):
                     bld.add_video_gap(gap)
                 else:
                     fv = Filter()
-                    fv.add_filter("trim", "%.3f" % start, "%.3f" % (start + gap))
+                    fv.add_filter(
+                        "trim", "%.3f" % start,
+                        "%.3f" % (start + gap))
                     fv.add_filter("setpts", "PTS-STARTPTS")
                     bld.add_video_content(0, ",".join(
                             list(filter(None, [vf(0), fv.to_str()]))))
@@ -95,11 +103,15 @@ def _build(args):
                 bld.add_audio_gap(gap)
             else:
                 fa = Filter()
-                fa.add_filter("atrim", "%.3f" % start, "%.3f" % (start + gap))
+                fa.add_filter(
+                    "atrim", "%.3f" % start,
+                    "%.3f" % (start + gap))
                 fa.add_filter("asetpts", "PTS-STARTPTS")
                 bld.add_audio_content(0, ",".join(
                         list(filter(None, [af(0), fa.to_str()]))))
-
+    for i in range(len(targets)):
+        start, gap = gaps[i]
+        _add_gap(start, gap)
         if targets_have_video or qual["has_video"][0]:
             if qual["has_video"][i + 1]:
                 bld.add_video_content(i + 1, vf(i + 1))
@@ -107,6 +119,9 @@ def _build(args):
                 # wav, mp3, etc...
                 bld.add_video_gap(einf[i + 1]["orig_duration"])
         bld.add_audio_content(i + 1, af(i + 1))
+    if end_pad and args.end_gap == "pad":
+        start, gap = gaps[len(targets)]
+        _add_gap(start, gap)
     fc, vmap, amap = bld.build()
     return [base] + targets, fc, [vmap], [amap]
 
@@ -153,12 +168,22 @@ The default is "do not align" (`omit`) because it is not normally suitable for t
 purpose of `concatanate`. The default is "omit" if there are two or more media \
 specified as "splitted". If there is only one media specified as "splitted", \
 the default is "pad", assuming your goal is to fill in the leading gap.""")
+    parser.add_argument(
+        '--end_gap', choices=['omit', 'pad'],
+        help="""\
+Controling whether to align the end position with `base` or not. \
+The default is "do not align" (`omit`) because it is not normally suitable for the \
+purpose of `concatanate`. The default is "omit" if there are two or more media \
+specified as "splitted". If there is only one media specified as "splitted", \
+the default is "pad", assuming your goal is to fill in the leading gap.""")
     #####
     parser.editor_add_extra_ffargs_arguments()
     #####
     args = parser.parse_args(args[1:])
     if not args.start_gap:
         args.start_gap = "omit" if len(args.splitted) > 1 else "pad"
+    if not args.end_gap:
+        args.end_gap = "omit" if len(args.splitted) > 1 else "pad"
     cli_common.logger_config()
 
     files, fc, vmap, amap = _build(args)

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -78,16 +78,13 @@ def _build(args):
     qual = SyncDetector.summarize_stream_infos(einf)
     targets_have_video = any(qual["has_video"][1:])
     outparams = args.outparams
-    if "fps" not in outparams or outparams["fps"] < 0:
-        outparams["fps"] = qual["max_fps"]
-    if "sample_rate" not in outparams or outparams["sample_rate"] < 0:
-        outparams["sample_rate"] = qual["max_sample_rate"]
+    outparams.fix_params(qual)
     bld = ConcatWithGapFilterGraphBuilder(
         "c",
         w=qual["max_width"],
         h=qual["max_height"],
-        fps=outparams["fps"],
-        sample_rate=outparams["sample_rate"])
+        fps=outparams.fps,
+        sample_rate=outparams.sample_rate)
     def _add_gap(start, gap):
         if gap > 0 and (
             not np.isclose(start, 0) or args.start_gap != "omit"):

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -162,14 +162,12 @@ the default is "pad", assuming your goal is to fill in the leading gap.""")
     cli_common.logger_config()
 
     files, fc, vmap, amap = _build(args)
-    v_extra_ffargs = args.v_extra_ffargs if vmap else []
-    a_extra_ffargs = args.a_extra_ffargs if amap else []
     call_ffmpeg_with_filtercomplex(
         args.mode,
         files,
         fc,
-        v_extra_ffargs + a_extra_ffargs,
-        zip(vmap, amap),
+        vmap, amap,
+        args.v_extra_ffargs, args.a_extra_ffargs,
         [args.outfile])
 
 

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -77,12 +77,17 @@ def _build(args):
     #
     qual = SyncDetector.summarize_stream_infos(einf)
     targets_have_video = any(qual["has_video"][1:])
+    outparams = args.outparams
+    if "fps" not in outparams or outparams["fps"] < 0:
+        outparams["fps"] = qual["max_fps"]
+    if "sample_rate" not in outparams or outparams["sample_rate"] < 0:
+        outparams["sample_rate"] = qual["max_sample_rate"]
     bld = ConcatWithGapFilterGraphBuilder(
         "c",
         w=qual["max_width"],
         h=qual["max_height"],
-        fps=qual["max_fps"],
-        sample_rate=qual["max_sample_rate"])
+        fps=outparams["fps"],
+        sample_rate=outparams["sample_rate"])
     def _add_gap(start, gap):
         if gap > 0 and (
             not np.isclose(start, 0) or args.start_gap != "omit"):
@@ -150,6 +155,7 @@ is detected by the "base" audio, this script fills it. However, \
 even if there is overlap, this script does not complain anything, \
 but it goes without saying that it's a "strange" movie.""")
     parser.editor_add_output_argument(default="concatenated.mp4")
+    parser.editor_add_output_params_argument()
     parser.editor_add_mode_argument()
     #
     #####

--- a/align_videos_by_soundtrack/edit_outparams.py
+++ b/align_videos_by_soundtrack/edit_outparams.py
@@ -33,10 +33,16 @@ class EditorOutputParams(object):
     gave errors but I also experienced a blue screen on Windows machines.
     It may be risky to unify to the highest fps when input with various
     fps mixed.
+
+    You can also specify width, and height. The point to decide from the
+    input file if neither is specified is the same as fps etc. If either
+    is specified, one is calculated based on the aspect ratio of the input.
     """
     def __init__(self, **kwargs):
         self.sample_rate = kwargs.get("sample_rate", -1)
         self.fps = kwargs.get("fps", 29.97)
+        self.width = kwargs.get("width", -1)
+        self.height = kwargs.get("height", -1)
 
     @staticmethod
     def from_json(s):
@@ -44,7 +50,7 @@ class EditorOutputParams(object):
             d = json_loads(s)
 
             tmpl = EditorOutputParams()
-            validate_dict_one_by_template(d, tmpl.__dict__)
+            validate_dict_one_by_template(d, tmpl.__dict__, not_empty=False)
             return EditorOutputParams(**d)
         return EditorOutputParams()
 
@@ -52,11 +58,23 @@ class EditorOutputParams(object):
         """
         inputs_qual: returned from SyncDetector.summarize_stream_infos.
         """
+        from fractions import Fraction
         if self.fps <= 0:
             self.fps = inputs_qual.get("max_fps", 29.97)
         if self.sample_rate <= 0:
             self.sample_rate = inputs_qual.get(
                 "max_sample_rate", 44100)
+        if self.width <= 0 and self.height <= 0:
+            self.width = inputs_qual.get("max_width", 1920)
+            self.height = inputs_qual.get("max_height", 1080)
+        elif self.width <= 0 or self.height <= 0:
+            w = inputs_qual.get("max_width", 1920)
+            h = inputs_qual.get("max_height", 1080)
+            aspect = Fraction.from_float(w/float(h)).limit_denominator(50)
+            if self.width <= 0:
+                self.width = (self.height * aspect).numerator
+            else:
+                self.height = (self.width / aspect).numerator
 
 
 if __name__ == "__main__":

--- a/align_videos_by_soundtrack/edit_outparams.py
+++ b/align_videos_by_soundtrack/edit_outparams.py
@@ -27,12 +27,12 @@ class EditorOutputParams(object):
     Parameter used by editor scripts.
 
     You can specify sample_rate, fps. In any case, if not specified,
-    or specified less equals zero, the maximum in the input movie is used.
-    Using the maximum in the input movie can cause problems with ffmpeg.
-    Especially fps is. Perhaps due to memory problems, ffmpeg not only
-    gave errors but I also experienced a blue screen on Windows machines.
-    It may be risky to unify to the highest fps when input with various
-    fps mixed.
+    or specified less equals zero, the maximum in the input movie is used
+    for sample_rate, 29.97 for fps. Using the maximum in the input movie
+    can cause problems with ffmpeg. Especially fps is. Perhaps due to
+    memory problems, ffmpeg not only gave errors but I also experienced
+    a blue screen on Windows machines. It may be risky to unify to the
+    highest fps when input with various fps mixed.
 
     You can also specify width, and height. The point to decide from the
     input file if neither is specified is the same as fps etc. If either

--- a/align_videos_by_soundtrack/edit_outparams.py
+++ b/align_videos_by_soundtrack/edit_outparams.py
@@ -48,6 +48,16 @@ class EditorOutputParams(object):
             return EditorOutputParams(**d)
         return EditorOutputParams()
 
+    def fix_params(self, inputs_qual):
+        """
+        inputs_qual: returned from SyncDetector.summarize_stream_infos.
+        """
+        if self.fps <= 0:
+            self.fps = inputs_qual.get("max_fps", 29.97)
+        if self.sample_rate <= 0:
+            self.sample_rate = inputs_qual.get(
+                "max_sample_rate", 44100)
+
 
 if __name__ == "__main__":
     import doctest

--- a/align_videos_by_soundtrack/edit_outparams.py
+++ b/align_videos_by_soundtrack/edit_outparams.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module contains only class for parameters of the editor
+scripts for output.
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import logging
+
+from . import communicate
+from .utils import (
+    json_loads,
+    validate_dict_one_by_template)
+
+
+__all__ = [
+    'EditorOutputParams',
+    ]
+
+_logger = logging.getLogger(__name__)
+
+
+class EditorOutputParams(object):
+    """
+    Parameter used by editor scripts.
+
+    You can specify sample_rate, fps. In any case, if not specified,
+    or specified less equals zero, the maximum in the input movie is used.
+    Using the maximum in the input movie can cause problems with ffmpeg.
+    Especially fps is. Perhaps due to memory problems, ffmpeg not only
+    gave errors but I also experienced a blue screen on Windows machines.
+    It may be risky to unify to the highest fps when input with various
+    fps mixed.
+    """
+    def __init__(self, **kwargs):
+        self.sample_rate = kwargs.get("sample_rate", -1)
+        self.fps = kwargs.get("fps", 29.97)
+
+    @staticmethod
+    def from_json(s):
+        if s:
+            d = json_loads(s)
+
+            tmpl = EditorOutputParams()
+            validate_dict_one_by_template(d, tmpl.__dict__)
+            return EditorOutputParams(**d)
+        return EditorOutputParams()
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -260,11 +260,10 @@ intercuts[%d]["video_mode_params"]""" % i, list_size_max=1)
 
 
 #
-def translate_definition(definition):
+def translate_inputs_definition(definition):
     _inputs = definition["inputs"]  # as human readable
-    _intercuts = definition["intercuts"]  # as human readable
     #
-    inputs = [  # flatten, parsed time
+    return [  # flatten, parsed time
         {
             "file": check_and_decode_filenames([inp["file"]], exit_if_error=True)[0],
             "v_extra_filter": inp.get("v_extra_filter"),
@@ -274,6 +273,9 @@ def translate_definition(definition):
             }
         for inp in [_inputs["main"]] + _inputs["sub"]]
 
+    
+def translate_intercuts_definition(definition):
+    _intercuts = definition["intercuts"]  # as human readable
     def _get_idx(p):
         if p == "main":
             return 0
@@ -330,7 +332,7 @@ def translate_definition(definition):
         #
         intercuts.append(ins)
 
-    return inputs, intercuts
+    return intercuts
 #
 
 
@@ -391,7 +393,8 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, clear_ca
             result[idx][np.where(result[idx] > dur)] = dur
         return result
     #
-    inputs, intercuts = translate_definition(definition)
+    inputs = translate_inputs_definition(definition)
+    intercuts = translate_intercuts_definition(definition)
     files = [inp["file"] for inp in inputs]
     with SyncDetector(
         params=summarizer_params,

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -690,14 +690,12 @@ position.")
     files, fc, vmap, amap = build(
         json_load(args.definition),
         args.known_delay_map, args.summarizer_params, args.clear_cache)
-    v_extra_ffargs = args.v_extra_ffargs if vmap else []
-    a_extra_ffargs = args.a_extra_ffargs if amap else []
     call_ffmpeg_with_filtercomplex(
         args.mode,
         files,
         fc,
-        v_extra_ffargs + a_extra_ffargs,
-        zip(vmap, amap) if vmap else [amap],
+        vmap, amap,
+        args.v_extra_ffargs, args.a_extra_ffargs,
         [args.outfile])
 
 

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -35,9 +35,9 @@ from .utils import (
     json_load,
     json_loads,
     validate_type_one_by_template,
-    validate_dict_one_by_template
+    validate_dict_one_by_template,
+    validate_list_of_dict_one_by_template
     )
-#from . import _cache
 from . import cli_common
 
 
@@ -230,6 +230,24 @@ def validate_definition(definition):
                     "'intercuts[%d]'" % i,
                     c["sub_idx"]))
             sys.exit(1)
+        if c["video_mode"] == "overlay":
+            validate_list_of_dict_one_by_template(
+                c["video_mode_params"], {
+                    "mode": "...",
+                    "cropping": "...",
+                    "overlay": "...",
+                    "partner_layer": "..."
+                    }, ["overlay"],
+                """(because "video_mode" is "overlay",) \
+intercuts[%d]["video_mode_params"]""" % i, list_size_max=1)
+        elif c["video_mode"] == "blend":
+            validate_list_of_dict_one_by_template(
+                c["video_mode_params"], {
+                    "blend": "...",
+                    "bottom_layer": "..."
+                    }, ["blend"],
+                """(because "video_mode" is "blend",) \
+intercuts[%d]["video_mode_params"]""" % i, list_size_max=1)
 
 
 def _make_list_of_trims(definition, known_delay_map, summarizer_params, clear_cache):

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -347,7 +347,7 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, clear_ca
         else:
             return t
     #
-    def _mk_trims_table(inputs, intercuts, einf, qual):
+    def _mk_trims_table(inputs, intercuts, einf):
         # result = [
         #   [[s1, e1],...],  # for idx=0
         #   ...
@@ -412,7 +412,7 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, clear_ca
         else:
             return np.isclose(s, e)
 
-    base_trims_table = _mk_trims_table(inputs, intercuts, einf, qual)
+    base_trims_table = _mk_trims_table(inputs, intercuts, einf)
     last = 0  # default bottom layer for blend
     for i, ins in enumerate(intercuts):
         if base_trims_table[0][i][0] >= base_trims_table[0][i][1]:

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -431,8 +431,8 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, clear_ca
         # [[idx, start, end], ...]
         trims = []
         use_indexes = [0]
+        params = ins["video_mode_params"]
         if ins["video_mode"] in ("overlay", "blend"):
-            params = ins["video_mode_params"]
             # for blend, it's top layer
             use_indexes.append(ins["idx"])
             #

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -529,7 +529,7 @@ def build(definition, known_delay_map, summarizer_params, outparams, clear_cache
     for inp in inputs:
         f_v = Filter()
         f_v.add_filter("fps", fps=outparams.fps)
-        f_v.add_filter("scale", qual["max_width"], qual["max_height"])
+        f_v.add_filter("scale", outparams.width, outparams.height)
         f_v.add_filter(inp.get("v_extra_filter"))
         f_v.add_filter("setpts", "PTS-STARTPTS")
         f_v.add_filter("setsar", "1")

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -266,7 +266,7 @@ def translate_definition(definition):
     #
     inputs = [  # flatten, parsed time
         {
-            "file": inp["file"],
+            "file": check_and_decode_filenames([inp["file"]], exit_if_error=True)[0],
             "v_extra_filter": inp.get("v_extra_filter"),
             "a_extra_filter": inp.get("a_extra_filter"),
             "start_time": parse_time(inp.get("start_time", 0)),
@@ -392,8 +392,7 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, clear_ca
         return result
     #
     inputs, intercuts = translate_definition(definition)
-    files = check_and_decode_filenames(
-        [inp["file"] for inp in inputs], exit_if_error=True)
+    files = [inp["file"] for inp in inputs]
     with SyncDetector(
         params=summarizer_params,
         clear_cache=clear_cache) as sd:

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -356,9 +356,9 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, outparam
         # the difference between the trim and atrim clipping
         # width becoming bigger because the video is far coarser
         # in resolution.
-        if outparams["fps"]:
-            nvframes = np.floor(t * outparams["fps"])
-            return nvframes / outparams["fps"]
+        if outparams.fps:
+            nvframes = np.floor(t * outparams.fps)
+            return nvframes / outparams.fps
         else:
             return t
     #
@@ -402,13 +402,9 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, outparam
 
     #
     qual = SyncDetector.summarize_stream_infos(einf)
-    if all(qual["has_video"]):
-        if "fps" not in outparams or outparams["fps"] <= 0:
-            outparams["fps"] = qual["max_fps"]
-    else:
-        outparams["fps"] = 0.
-    if "sample_rate" not in outparams or outparams["sample_rate"] <= 0:
-        outparams["sample_rate"] = qual["max_sample_rate"]
+    outparams.fix_params(qual)
+    if not all(qual["has_video"]):
+        outparams.fps = 0.
 
     # make a list of time ranges which will be used as trim, and atrim.
     trims_list = []
@@ -417,8 +413,8 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, outparam
         if s < 0 or e < 0:
             return True
         # trim doesn't work if dur is smaller than gap between frames.
-        if outparams["fps"]:
-            return (e - s) < 1./outparams["fps"]
+        if outparams.fps:
+            return (e - s) < 1./outparams.fps
         else:
             return np.isclose(s, e)
 
@@ -532,13 +528,13 @@ def build(definition, known_delay_map, summarizer_params, outparams, clear_cache
     ftmpl = []
     for inp in inputs:
         f_v = Filter()
-        f_v.add_filter("fps", fps=outparams["fps"])
+        f_v.add_filter("fps", fps=outparams.fps)
         f_v.add_filter("scale", qual["max_width"], qual["max_height"])
         f_v.add_filter(inp.get("v_extra_filter"))
         f_v.add_filter("setpts", "PTS-STARTPTS")
         f_v.add_filter("setsar", "1")
         f_a = Filter()
-        f_a.add_filter("aresample", outparams["sample_rate"])
+        f_a.add_filter("aresample", outparams.sample_rate)
         f_a.add_filter(inp.get("a_extra_filter"))
         f_a.add_filter("asetpts", "PTS-STARTPTS")
         ftmpl.append((f_v, f_a))

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -241,8 +241,6 @@ it takes from max sample rate of input medias. (default: %(default)d)")
     cli_common.logger_config()
     
     files, fc, (vmap, amap) = _build(args)
-    v_extra_ffargs = args.v_extra_ffargs if vmap else []
-    a_extra_ffargs = args.a_extra_ffargs if amap else []
     if args.video_mode == 'indivisual' or args.audio_mode == 'indivisual':
         outbase, outext = os.path.splitext(args.outfile)
         outfiles = ["{}_{:02d}{}".format(outbase, i, outext)
@@ -254,8 +252,8 @@ it takes from max sample rate of input medias. (default: %(default)d)")
         args.mode,
         files,
         fc,
-        v_extra_ffargs + a_extra_ffargs,
-        zip(vmap, amap),
+        vmap, amap,
+        args.v_extra_ffargs, args.a_extra_ffargs,
         outfiles)
 
 

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -142,13 +142,18 @@ def _build(args):
             files,
             known_delay_map=args.known_delay_map)
     qual = SyncDetector.summarize_stream_infos(ares)
+    outparams = args.outparams
+    if "fps" not in outparams or outparams["fps"] <= 0:
+        outparams["fps"] = qual["max_fps"]
+    if "sample_rate" not in outparams or outparams["sample_rate"] <= 0:
+        outparams["sample_rate"] = qual["max_sample_rate"]
 
     b = _StackVideosFilterGraphBuilder(
         shape=shape,
         w=args.w,
         h=args.h,
-        fps=qual["max_fps"],
-        sample_rate=args.sample_rate if args.sample_rate else qual["max_sample_rate"])
+        fps=outparams["fps"],
+        sample_rate=outparams["sample_rate"])
 
     for i, inf in enumerate(ares):
         pre, post = inf["pad"], inf["pad_post"]
@@ -203,6 +208,7 @@ different thing from this. See the option description.""")
         "files", nargs="+",
         help="The media files which contains both video and audio.")
     parser.editor_add_output_argument(default="merged.mp4")
+    parser.editor_add_output_params_argument()
     parser.editor_add_mode_argument()
     #####
     parser.add_argument(
@@ -224,10 +230,6 @@ implies --audio_mode='indivisual'. (default: %(default)s)""")
     parser.add_argument(
         '--shape', type=str, default="[2, 2]",
         help="The shape of the tile, like '[2, 2]'. (default: %(default)s)")
-    parser.add_argument(
-        '--sample_rate', type=int, default=0,
-        help="Sampling rate of the output file. Passing zero means that \
-it takes from max sample rate of input medias. (default: %(default)d)")
     parser.add_argument(
         '--width-per-cell', dest="w", type=int, default=960,
         help="Width of the cell. (default: %(default)d)")

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -143,17 +143,14 @@ def _build(args):
             known_delay_map=args.known_delay_map)
     qual = SyncDetector.summarize_stream_infos(ares)
     outparams = args.outparams
-    if "fps" not in outparams or outparams["fps"] <= 0:
-        outparams["fps"] = qual["max_fps"]
-    if "sample_rate" not in outparams or outparams["sample_rate"] <= 0:
-        outparams["sample_rate"] = qual["max_sample_rate"]
+    outparams.fix_params(qual)
 
     b = _StackVideosFilterGraphBuilder(
         shape=shape,
         w=args.w,
         h=args.h,
-        fps=outparams["fps"],
-        sample_rate=outparams["sample_rate"])
+        fps=outparams.fps,
+        sample_rate=outparams.sample_rate)
 
     for i, inf in enumerate(ares):
         pre, post = inf["pad"], inf["pad_post"]

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -205,7 +205,8 @@ different thing from this. See the option description.""")
         "files", nargs="+",
         help="The media files which contains both video and audio.")
     parser.editor_add_output_argument(default="merged.mp4")
-    parser.editor_add_output_params_argument()
+    parser.editor_add_output_params_argument(
+        notice="Note: In this script, width and height are ignored.")
     parser.editor_add_mode_argument()
     #####
     parser.add_argument(

--- a/align_videos_by_soundtrack/trim.py
+++ b/align_videos_by_soundtrack/trim.py
@@ -45,7 +45,7 @@ Trim media based on synchronization with audio tracks.""")
     if not os.path.exists(args.outdir):
         os.mkdir(args.outdir)
     with SyncDetector(
-        params=args.summarizer_params
+        params=args.summarizer_params,
         clear_cache=args.clear_cache) as sd:
         infos = sd.align(
             files,

--- a/align_videos_by_soundtrack/utils.py
+++ b/align_videos_by_soundtrack/utils.py
@@ -17,6 +17,9 @@ __all__ = [
     "check_and_decode_filenames",
     "json_load",
     "json_loads",
+    "validate_type_one_by_template",
+    "validate_dict_one_by_template",
+    "validate_list_of_dict_one_by_template",
     ]
 
 _logger = logging.getLogger(__name__)
@@ -85,11 +88,27 @@ def json_load(jsonfilename):
 # Validation helpers
 #
 def validate_type_one_by_template(
-    chktrg, tmpl, depthstr="", not_empty=True, exit_on_error=True):
+    chktrg, tmpl, depthstr="",
+    size_min=1, size_max=-1, exit_on_error=True):
 
-    if type(chktrg) != type(tmpl) or not chktrg:
+    if type(chktrg) != type(tmpl):
         _logger.error("""%s must be %s""" % (
                 depthstr, type(tmpl)))
+        if exit_on_error:
+            sys.exit(1)
+        return False
+    if ((size_min > 0 and len(chktrg) < size_min) or (
+            size_max > 0 and len(chktrg) > size_max)):
+        if size_min > 0 and size_max <= 0:
+            bs = "greater equal than %d" % size_min
+        elif size_min <= 0 and size_max > 0:
+            bs = "less equal than %d" % size_max
+        elif size_min == size_max:
+            bs = "%d" % (size_min)
+        else:
+            bs = "between %d and %d" % (size_min, size_max)
+        _logger.error("""The length of %s must be %s""" % (
+                depthstr, bs))
         if exit_on_error:
             sys.exit(1)
         return False
@@ -100,7 +119,9 @@ def validate_dict_one_by_template(
     chktrg, tmpl, mandkeys=[], depthstr="", not_empty=True, exit_on_error=True):
 
     if not validate_type_one_by_template(
-        chktrg, tmpl, depthstr, not_empty, exit_on_error):
+        chktrg, tmpl, depthstr,
+        size_min=1 if (not_empty or mandkeys) else 0,
+        exit_on_error=exit_on_error):
         return False
     depthstr = "in %s" % depthstr if depthstr else ""
     for mk in mandkeys:
@@ -118,6 +139,26 @@ def validate_dict_one_by_template(
         if exit_on_error:
             sys.exit(1)
         return False
+    return True
+
+
+def validate_list_of_dict_one_by_template(
+    chktrg, itemdict_tmpl, itemdict_mandkeys=[], depthstr="",
+    list_size_min=1, list_size_max=-1,
+    itemdict_not_empty=True, exit_on_error=True):
+
+    if not validate_type_one_by_template(
+        chktrg, [itemdict_tmpl], depthstr,
+        list_size_min, list_size_max, exit_on_error):
+        return False
+
+    for i, td in enumerate(chktrg):
+        if not validate_dict_one_by_template(
+            td, itemdict_tmpl, itemdict_mandkeys,
+            depthstr + "[%d]" % i,
+            itemdict_not_empty,
+            exit_on_error):
+            return False
     return True
 
 


### PR DESCRIPTION
The number of commits is large, but the bug fix is almost about "known_delay_map". The handled part of "known_delay_map" was quite wrong and we were only about half what we said. 

One of remodeling about "simple_compile_videos_by_sound_track" and "concat_videos_by_sound_track" is paired. "simple_compile_videos_by_sound_track" made it possible to specify "start_time" and "end_time" for "main", but this means to ignore all cuts after the end of "main". That means that if you have a movie that has been shotting the end of the event longer than "main", you can not use this end. What was done on "concat_videos_by_sound_track" is a remedy for this. (As for `v_extra_filter, a_extra_filter for intercuts`, I think that you can understand without saying that I omit it in detail.)

Another modification is the introduction of EditorOutputParams. I was trying to unify the input at the maximum, but ffmpeg had fatal abnormal behaviors when I was dealing with things with 60 fps input mixed, I was going to experience the blue screen. Therefore, I thought that it would be risky to adopt the maximum as the default.