### PR TITLE
simple_compile_videos_by_sound_track updated

### DIFF
--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -685,11 +685,10 @@ Do you scan the current directory and create an information file? [y/n] """)
             einf = sd.align(
                 files,
                 known_delay_map=args.known_delay_map)
-            idx = 0
             dur = int(infos[0][1]["duration"])
             step = 5
             selected = -1
-            for t in range(0, dur, step):
+            for idx, t in enumerate(range(0, dur, step)):
                 cands = [i for i, ta in [(i, t - (einf[i + 1]["pad"] - einf[0]["pad"]))
                          for i in range(len(result["inputs"]["sub"]))]
                          if ta + step < einf[i + 1]["orig_duration"] and \
@@ -706,7 +705,6 @@ Do you scan the current directory and create an information file? [y/n] """)
                         "audio_mode": "select",
                         "audio_mode_params": ["sub"],
                         })
-                idx += 1
 
     ofn = input("""\
 What sort of name will you save this definition? [default: sample.json] """)

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -420,6 +420,37 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, outparam
 
     base_trims_table = _mk_trims_table(inputs, intercuts, einf)
     last = 0  # default bottom layer for blend
+    def _get_trims(i, idx):
+        s, e = base_trims_table[idx][i]
+        if (s >= 0 and e >= 0):
+            return (idx, s, e)
+        else:
+            # If the start time or end time are negative,
+            # that is, if this sub material does not exist
+            # at that time (at "main" counting), let's replace
+            # it with the other material with warning.
+            # Funny things happen, such as overlaying "main"
+            # on "main", or amergeing "main" and "main"
+            # depending on user's instructions, but I do not
+            # mind as long as a warning is issued.
+            for alt in range(len(base_trims_table)):
+                sa, ea = base_trims_table[alt][i]
+                if (sa >= 0 and ea >= 0):
+                    _logger.warn("""\
+Negative time was found %s for '%s'. \
+We used '%s' %s instead.""",
+                                 duration_to_hhmmss(s, e),
+                                 os.path.basename(files[idx]),
+                                 os.path.basename(files[alt]),
+                                 duration_to_hhmmss(sa, ea))
+                    return (alt, sa, ea)
+            else:
+                _logger.error("""\
+Negative time was found %s for '%s'. """,
+                              duration_to_hhmmss(s, e),
+                              os.path.basename(files[idx]))
+                sys.exit(1)
+
     for i, ins in enumerate(intercuts):
         if base_trims_table[0][i][0] >= base_trims_table[0][i][1]:
             # Start >= end, that is, it was completely filled in
@@ -447,36 +478,7 @@ def _make_list_of_trims(definition, known_delay_map, summarizer_params, outparam
         astart_of_use_indexes = len(use_indexes)
         use_indexes.extend(ins["audio_mode_params"])
         for idx in use_indexes:
-            s, e = base_trims_table[idx][i]
-            if (s >= 0 and e >= 0):
-                trims.append((idx, s, e))
-            else:
-                # If the start time or end time are negative,
-                # that is, if this sub material does not exist
-                # at that time (at "main" counting), let's replace
-                # it with the other material with warning.
-                # Funny things happen, such as overlaying "main"
-                # on "main", or amergeing "main" and "main"
-                # depending on user's instructions, but I do not
-                # mind as long as a warning is issued.
-                for alt in range(len(base_trims_table)):
-                    sa, ea = base_trims_table[alt][i]
-                    if (sa >= 0 and ea >= 0):
-                        _logger.warn("""\
-Negative time was found %s for '%s'. \
-We used '%s' %s instead.""",
-                                     duration_to_hhmmss(s, e),
-                                     os.path.basename(files[idx]),
-                                     os.path.basename(files[alt]),
-                                     duration_to_hhmmss(sa, ea))
-                        trims.append((alt, sa, ea))
-                        break
-                else:
-                    _logger.error("""\
-Negative time was found %s for '%s'. """,
-                                  duration_to_hhmmss(s, e),
-                                  os.path.basename(files[idx]))
-                    sys.exit(1)
+            trims.append(_get_trims(i, idx))
         trims = np.array(trims)
         trims[:,2] = trims[:,1] + (trims[:,2] - trims[:,1]).min()
         if not _desired_dur_is_too_small(st_main, trims[0,1]):

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -464,21 +464,20 @@ Negative time was found %s for '%s'. """,
                     "v_extra_filter", "a_extra_filter")
                 })
         # [[idx, start, end], ...]
-        trims = []
-        use_indexes = [0]
+        trims = [_get_trims(i, 0)]
         params = ins["video_mode_params"]
         if ins["video_mode"] in ("overlay", "blend"):
             # for blend, it's top layer
-            use_indexes.append(ins["idx"])
+            trims.append(_get_trims(i, ins["idx"]))
             #
-            use_indexes.append(
-                params[0].get("partner_layer", int(last) - 1))
+            trims.append(
+                _get_trims(
+                    i, params[0].get("partner_layer", int(last) - 1)))
         else:  # select
-            use_indexes.append(params[0])
-        astart_of_use_indexes = len(use_indexes)
-        use_indexes.extend(ins["audio_mode_params"])
-        for idx in use_indexes:
-            trims.append(_get_trims(i, idx))
+            trims.append(_get_trims(i, params[0]))
+        astart_of_use_indexes = len(trims)
+        trims.extend(
+            [_get_trims(i, p) for p in ins["audio_mode_params"]])
         trims = np.array(trims)
         trims[:,2] = trims[:,1] + (trims[:,2] - trims[:,1]).min()
         if not _desired_dur_is_too_small(st_main, trims[0,1]):

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -688,15 +688,17 @@ Do you scan the current directory and create an information file? [y/n] """)
             idx = 0
             dur = int(infos[0][1]["duration"])
             step = 5
+            selected = -1
             for t in range(0, dur, step):
                 cands = [i for i, ta in [(i, t - (einf[i + 1]["pad"] - einf[0]["pad"]))
                          for i in range(len(result["inputs"]["sub"]))]
                          if ta + step < einf[i + 1]["orig_duration"] and \
                              ta >= 0 and ta + step >= 0]
-                if not cands:
+                if not cands or selected == cands[idx % len(cands)]:
                     continue
+                selected = cands[idx % len(cands)]
                 result["intercuts"].append({
-                        "sub_idx": cands[idx % len(cands)],
+                        "sub_idx": selected,
                         "start_time": duration_to_hhmmss(t),
                         "time_origin": "main",
                         "video_mode": "select",


### PR DESCRIPTION
* Fixed incorrect behavior when omitting "partner_layer". 
* It is ridiculous to combine successive trimmed media, so we decided to omit the same object.