### PR TITLE
simple_html5_simult_player_builder_by_sound_track

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,14 @@ Usage:
     simple_compile_videos_by_sound_track edit_definitionfile
 
 See `simple_compile_videos_by_sound_track --help` for more details.
+
+### simple_html5_simult_player_builder_by_sound_track
+This script creates a simultaneous playing player using the video (or audio) elements
+of html 5.
+
+It is similar to "simple_stack_videos_by_sound_track", but since it does not involve media
+editing, it will be very useful if you want to know the result quickly.
+
+Usage:
+
+    simple_html5_simult_player_builder_by_sound_track <file1> <file2> [<file3>…]

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -98,8 +98,9 @@ _MEDIA_TYPES = {
     (".ogg", True): ("video", "video/ogg"),
 
     (".mp3", False): ("audio", "audio/mpeg"),
-    (".ogg", False): ("video", "audio/ogg"),
-    # TODO: more!
+    (".ogg", False): ("audio", "audio/ogg"),
+    (".wav", False): ("audio", "audio/wav"),
+    # TODO: more? (WebM	video/webm, or extension variations like ".mpeg4")
     }
 
 

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -54,7 +54,7 @@ function advance(v) {
     });
     sync();
     if (!paused) {
-        setTimeout(play, plyrs.length * 700);
+        setTimeout(play, plyrs.length * 900);
     }
 }
 $(document).ready(function() {
@@ -67,12 +67,18 @@ $(document).ready(function() {
 </head>
 <body>
 <div>
+<button onclick="advance(-60.0);">-60</button>
+<button onclick="advance(-30.0);">-30</button>
 <button onclick="advance(-15.0);">-15</button>
 <button onclick="advance(-5.0);">-5</button>
+&nbsp;
 <button onclick="play();">Play</button>
 <button onclick="pause();">Pause</button>
+&nbsp;
 <button onclick="advance(5.0);">+5</button>
 <button onclick="advance(15.0);">+15</button>
+<button onclick="advance(30.0);">+30</button>
+<button onclick="advance(60.0);">+60</button>
 </div>
 
 %(medias_tab)s

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -96,11 +96,15 @@ _MEDIA_TYPES = {
     (".mp4", True): ("video", "video/mp4"),
     (".mp4", False): ("video", "video/mp4"),
     (".ogg", True): ("video", "video/ogg"),
+    (".ogv", True): ("video", "video/ogg"),
+    # TODO: .ogx, .ogm, .spx, .opus
+    (".webm", True): ("video", "video/webm"),
 
     (".mp3", False): ("audio", "audio/mpeg"),
     (".ogg", False): ("audio", "audio/ogg"),
+    (".oga", False): ("audio", "audio/ogg"),
     (".wav", False): ("audio", "audio/wav"),
-    # TODO: more? (WebM	video/webm, or extension variations like ".mpeg4")
+    # TODO: more? (extension variations like ".mpeg4")
     }
 
 

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -80,10 +80,16 @@ $(document).ready(function() {
 </body>
 </html>"""
 
-_tmpl_media = """\
+_tmpl_media = {
+    True: """\
 <%(media_type)s id="%(ident_prefix)s%(index)d" width="%(width)d" height="%(height)d">
   <source src="%(media)s" type="%(media_detailtype)s">
-</%(media_type)s>"""
+</%(media_type)s>""",
+    False: """\
+<%(media_type)s id="%(ident_prefix)s%(index)d">
+  <source src="%(media)s" type="%(media_detailtype)s">
+</%(media_type)s>""",
+}
 
 
 _MEDIA_TYPES = {
@@ -113,7 +119,7 @@ def build(args):
     for i, inf in enumerate(einf):
         ext = os.path.splitext(args.files[i])[1].lower()
         has_video = inf["orig_streams_summary"]["num_video_streams"] > 0
-        medias.append(_tmpl_media % dict(
+        medias.append(_tmpl_media[has_video] % dict(
                 media_type=_MEDIA_TYPES[(ext, has_video)][0],
                 ident_prefix=ident_prefix,
                 index=i,

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -45,6 +45,14 @@ function sync() {
             p.currentTime = now + delays[i];
         });
 }
+function resync(v) {
+    let paused = plyrs.findIndex(function (e) { return e.paused; }) >= 0;
+    pause();
+    sync();
+    if (!paused) {
+        setTimeout(play, plyrs.length * 900);
+    }
+}
 function advance(v) {  /* if v==0, we'll reset to start. */
     let paused = plyrs.findIndex(function (e) { return e.paused; }) >= 0;
     pause();
@@ -72,6 +80,9 @@ $(document).ready(function() {
 <div>
 <button onclick="play();">Play</button>
 <button onclick="pause();">Pause</button>
+&nbsp;
+<button onclick="resync();">Re-Sync</button>
+&nbsp;
 &nbsp;
 &nbsp;
 <button onclick="advance(-60.0);">-60</button>

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -105,11 +105,11 @@ $(document).ready(function() {
 
 _tmpl_media = {
     True: """\
-<%(media_type)s id="%(ident_prefix)s%(index)d" width="%(width)d" height="%(height)d">
+<%(media_type)s id="%(ident_prefix)s%(index)d" width="%(width)d" height="%(height)d" controls>
   <source src="%(media)s" type="%(media_detailtype)s">
 </%(media_type)s>""",
     False: """\
-<%(media_type)s id="%(ident_prefix)s%(index)d">
+<%(media_type)s id="%(ident_prefix)s%(index)d" controls>
   <source src="%(media)s" type="%(media_detailtype)s">
 </%(media_type)s>""",
 }

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -1,0 +1,169 @@
+#! /bin/env python
+# -*- coding: utf-8 -*-
+"""
+This module is intended as an example of one application of
+"align_videos_by_soundtrack.align".
+"""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+import os
+import sys
+import json
+import logging
+
+from .align import SyncDetector
+from .utils import check_and_decode_filenames
+from . import cli_common
+from .utils import (
+    check_and_decode_filenames,
+    path2url,
+)
+
+
+_logger = logging.getLogger(__name__)
+
+
+_tmpl_outer = """\
+<html>
+<head>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+<script>
+const delays = %(delays)s;
+const base = delays.find(function (e) { return e == 0.0; });
+const plyrs = [];
+
+function play() {
+    plyrs.forEach(function (p, i) { p.play(); });
+}
+function pause() {
+    plyrs.forEach(function (p, i) { p.pause(); });
+}
+function sync() {
+    let now = plyrs[base].currentTime;
+    plyrs.forEach(function (p, i) {
+            p.currentTime = now + delays[i];
+        });
+}
+function advance(v) {
+    let paused = plyrs.findIndex(function (e) { return e.paused; }) >= 0;
+    pause();
+    let now = plyrs[base].currentTime;
+    plyrs.forEach(function (p, i) {
+        p.currentTime = now + v;
+    });
+    sync();
+    if (!paused) {
+        setTimeout(play, plyrs.length * 700);
+    }
+}
+$(document).ready(function() {
+    for (i = 0; i < delays.length; ++i) {
+        plyrs.push(document.getElementById("%(ident_prefix)s" + i));
+    }
+    sync();
+});
+</script>
+</head>
+<body>
+<div>
+<button onclick="advance(-15.0);">-15</button>
+<button onclick="advance(-5.0);">-5</button>
+<button onclick="play();">Play</button>
+<button onclick="pause();">Pause</button>
+<button onclick="advance(5.0);">+5</button>
+<button onclick="advance(15.0);">+15</button>
+</div>
+
+%(medias_tab)s
+
+</body>
+</html>"""
+
+_tmpl_media = """\
+<%(media_type)s id="%(ident_prefix)s%(index)d" width="%(width)d" height="%(height)d">
+  <source src="%(media)s" type="%(media_detailtype)s">
+</%(media_type)s>"""
+
+
+_MEDIA_TYPES = {
+    (".mp4", True): ("video", "video/mp4"),
+    (".mp4", False): ("video", "video/mp4"),
+    (".ogg", True): ("video", "video/ogg"),
+
+    (".mp3", False): ("audio", "audio/mpeg"),
+    (".ogg", False): ("video", "audio/ogg"),
+    # TODO: more!
+    }
+
+
+def build(args):
+    shape = json.loads(args.shape) if args.shape else (2, 2)
+    files = check_and_decode_filenames(args.files)
+    with SyncDetector(
+        params=args.summarizer_params,
+        clear_cache=args.clear_cache) as sd:
+        einf = sd.align(
+            files,
+            known_delay_map=args.known_delay_map)
+
+    ident_prefix = "simltplayer"
+
+    medias = []
+    for i, inf in enumerate(einf):
+        ext = os.path.splitext(args.files[i])[1].lower()
+        has_video = inf["orig_streams_summary"]["num_video_streams"] > 0
+        medias.append(_tmpl_media % dict(
+                media_type=_MEDIA_TYPES[(ext, has_video)][0],
+                ident_prefix=ident_prefix,
+                index=i,
+                width=args.w,
+                height=args.h,
+                media=path2url(files[i]),
+                media_detailtype=_MEDIA_TYPES[(ext, has_video)][1],
+                ))
+
+    medias_tab = ["<table>"]
+    for i, m in enumerate(medias):
+        if i % shape[0] == 0:
+            if i > 0:
+                medias_tab.append("</tr>")
+            medias_tab.append("<tr>")
+        medias_tab.append("<td>")
+        medias_tab.append(m)
+        medias_tab.append("</td>")
+    medias_tab.append("</tr>")
+    medias_tab.append("</table>")
+
+    outer = _tmpl_outer % dict(
+        ident_prefix=ident_prefix,
+        delays=[float("%.3f" % inf["trim"]) for inf in einf],
+        medias_tab="\n".join(medias_tab))
+    return outer
+
+
+def main(args=sys.argv):
+    parser = cli_common.AvstArgumentParser(description="""\
+Create a simultaneous playing player using the video and audio elements of html 5.""")
+    parser.add_argument(
+        "files", nargs="+",
+        help="The media files which contains both video and audio.")
+    #####
+    parser.add_argument(
+        '--shape', type=str, default="[2, 2]",
+        help="The shape of the tile, like '[2, 2]'. (default: %(default)s)")
+    parser.add_argument(
+        '--width-per-cell', dest="w", type=int, default=480,
+        help="Width of the cell. (default: %(default)d)")
+    parser.add_argument(
+        '--height-per-cell', dest="h", type=int, default=270,
+        help="Height of the cell. (default: %(default)d)")
+    #####
+    args = parser.parse_args(args[1:])
+    cli_common.logger_config()
+    print(build(args))
+
+
+#
+if __name__ == '__main__':
+    main()

--- a/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
+++ b/align_videos_by_soundtrack/simple_html5_simult_player_builder.py
@@ -45,14 +45,17 @@ function sync() {
             p.currentTime = now + delays[i];
         });
 }
-function advance(v) {
+function advance(v) {  /* if v==0, we'll reset to start. */
     let paused = plyrs.findIndex(function (e) { return e.paused; }) >= 0;
     pause();
     let now = plyrs[base].currentTime;
     plyrs.forEach(function (p, i) {
-        p.currentTime = now + v;
+        if (v) {
+            p.currentTime = now + v + delays[i];
+        } else {
+            p.currentTime = delays[i];
+        }
     });
-    sync();
     if (!paused) {
         setTimeout(play, plyrs.length * 900);
     }
@@ -67,13 +70,16 @@ $(document).ready(function() {
 </head>
 <body>
 <div>
+<button onclick="play();">Play</button>
+<button onclick="pause();">Pause</button>
+&nbsp;
+&nbsp;
 <button onclick="advance(-60.0);">-60</button>
 <button onclick="advance(-30.0);">-30</button>
 <button onclick="advance(-15.0);">-15</button>
 <button onclick="advance(-5.0);">-5</button>
 &nbsp;
-<button onclick="play();">Play</button>
-<button onclick="pause();">Pause</button>
+<button onclick="advance(0);">0</button>
 &nbsp;
 <button onclick="advance(5.0);">+5</button>
 <button onclick="advance(15.0);">+15</button>

--- a/align_videos_by_soundtrack/utils.py
+++ b/align_videos_by_soundtrack/utils.py
@@ -20,6 +20,7 @@ __all__ = [
     "validate_type_one_by_template",
     "validate_dict_one_by_template",
     "validate_list_of_dict_one_by_template",
+    "path2url",
     ]
 
 _logger = logging.getLogger(__name__)
@@ -160,6 +161,22 @@ def validate_list_of_dict_one_by_template(
             exit_on_error):
             return False
     return True
+
+
+try:
+    import pathlib  # python 3.4+
+
+    def path2url(path):
+        return pathlib.Path(os.path.abspath(path)).as_uri()
+except ImportError:
+    # python 2
+    # (we would not support python 3.0 ~ 3.3.)
+    import urlparse
+    import urllib
+
+    def path2url(path):
+        return urlparse.urljoin(
+            'file:', urllib.pathname2url(os.path.abspath(path)))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ else:
                 'simple_stack_videos_by_sound_track = align_videos_by_soundtrack.simple_stack_videos:main',
                 'trim_by_sound_track = align_videos_by_soundtrack.trim:main',
                 'simple_compile_videos_by_sound_track = align_videos_by_soundtrack.simple_compile_videos:main',
+                'simple_html5_simult_player_builder_by_sound_track = align_videos_by_soundtrack.simple_html5_simult_player_builder:main',
                 ],
         },
     }


### PR DESCRIPTION
This script creates a simultaneous playing player using the video (or audio) elements
of html 5.

It is similar to "simple_stack_videos_by_sound_track", but since it does not involve media
editing, it will be very useful if you want to know the result quickly.
