### PR TITLE
Compactification of generated script

### DIFF
--- a/align_videos_by_soundtrack/cli_common.py
+++ b/align_videos_by_soundtrack/cli_common.py
@@ -103,6 +103,11 @@ for some reason, specify this.''' % (
     #
     # for editors
     #
+    def editor_add_userelpath_argument(self):
+        self.add_argument(
+            "--relpath", action="store_true",
+            help="Specifying whether to use relative path in generated script.")
+
     def editor_add_output_argument(self, default):
         self.add_argument(
             "-o", "--outfile", dest="outfile", default=default,

--- a/align_videos_by_soundtrack/concat.py
+++ b/align_videos_by_soundtrack/concat.py
@@ -151,6 +151,7 @@ chronological order. When concatenating, if there is a gap which \
 is detected by the "base" audio, this script fills it. However, \
 even if there is overlap, this script does not complain anything, \
 but it goes without saying that it's a "strange" movie.""")
+    parser.editor_add_userelpath_argument()
     parser.editor_add_output_argument(default="concatenated.mp4")
     parser.editor_add_output_params_argument()
     parser.editor_add_mode_argument()
@@ -200,7 +201,8 @@ the default is "pad", assuming your goal is to fill in the leading gap.""")
         fc,
         vmap, amap,
         args.v_extra_ffargs, args.a_extra_ffargs,
-        [args.outfile])
+        [args.outfile],
+        args.relpath)
 
 
 #

--- a/align_videos_by_soundtrack/ffmpeg_filter_graph.py
+++ b/align_videos_by_soundtrack/ffmpeg_filter_graph.py
@@ -148,22 +148,17 @@ class ConcatWithGapFilterGraphBuilder(object):
         fpadv.ov.append("[gap{gapno}v%s]" % ident)
         self._tmpl_gapv = (fpadv.to_str(), "".join(fpadv.ov))
 
-        # silence left; silence right; -> amerge
-        fpada = [Filter(), Filter(), Filter()]
+        # aevalsrc
         nch = 2
-        for i in range(nch):
-            fpada[i].add_filter(
-                "sine", sample_rate="%d" % sample_rate,
-                d="{duration:.3f}")
-            olab = "[gap{{gapno}}a_c{i}_{ident}]".format(ident=ident, i=i)
-            fpada[i].oa.append(olab)
-            fpada[-1].iv.append(olab)
-        fpada[-1].add_filter("amerge", len(fpada[-1].iv))
-        fpada[-1].oa.append("[gap{{gapno}}a{ident}]".format(ident=ident))
+        fpada = Filter()
+        fpada.add_filter(
+            "aevalsrc",
+            exprs="'%s'" % ("|".join(["0"] * nch)),
+            sample_rate="%d" % sample_rate,
+            d="{duration:.3f}")
+        fpada.oa.append("[gap{{gapno}}a{ident}]".format(ident=ident))
         self._tmpl_gapa = (
-            ";\n".join([fpada[i].to_str()
-                        for i in range(len(fpada))]),
-            "".join(fpada[-1].oa))
+            fpada.to_str(), "".join(fpada.oa))
 
         # filter to original video stream
         fbodyv = Filter()

--- a/align_videos_by_soundtrack/simple_compile_videos.py
+++ b/align_videos_by_soundtrack/simple_compile_videos.py
@@ -772,6 +772,7 @@ who are only interested in the most basic use cases.
                         help="\
 Text (JSON) file describing the definition for indicating the intercuts \
 position.")
+    parser.editor_add_userelpath_argument()
     parser.editor_add_output_argument(default="compiled.mp4")
     parser.editor_add_output_params_argument()
     parser.editor_add_mode_argument()
@@ -797,7 +798,8 @@ position.")
         fc,
         vmap, amap,
         args.v_extra_ffargs, args.a_extra_ffargs,
-        [args.outfile])
+        [args.outfile],
+        args.relpath)
 
 
 #

--- a/align_videos_by_soundtrack/simple_stack_videos.py
+++ b/align_videos_by_soundtrack/simple_stack_videos.py
@@ -215,6 +215,7 @@ This program combines movies of multiple angles in a tile shape with "hstack" an
 based on sound track synchronization. Although it is a program for the main object
 to arrange tile-like and simultaneous playback, it is possible to do a little
 different thing from this. See the option description.""")
+    parser.editor_add_userelpath_argument()
     parser.add_argument(
         "files", nargs="+",
         help="The media files which contains both video and audio.")
@@ -268,7 +269,8 @@ implies --audio_mode='individual'. (default: %(default)s)""")
         fc,
         vmap, amap,
         args.v_extra_ffargs, args.a_extra_ffargs,
-        outfiles)
+        outfiles,
+        args.relpath)
 
 
 #


### PR DESCRIPTION
1. Use of "aevalsrc"
2. Use of relpath

Although not a big deal, personally I was concerned about "feeling of pressure". Depending on whether you want to manually edit the generated scripts, if so, this fix may be nice for those people.